### PR TITLE
fix: wire the testing graph's HALT node so a stop writes its bundle (Closes #2756)

### DIFF
--- a/assemblyzero/workflows/testing/atlas.py
+++ b/assemblyzero/workflows/testing/atlas.py
@@ -40,7 +40,7 @@ ATLAS: dict[str, dict] = {
         ),
         "successors": {
             "N1_review_test_plan": "the LLD and spec loaded",
-            "END": "neither document could be loaded",
+            "HALT": "neither document could be loaded",
         },
     },
     "N1_review_test_plan": {
@@ -55,7 +55,8 @@ ATLAS: dict[str, dict] = {
         "successors": {
             "N2_scaffold_tests": "the plan is usable",
             "N1_5_revise_test_plan": "blocked; revise the plan once",
-            "END": "the reviewer failed, or the plan cannot be revised",
+            "HALT": "the reviewer failed and left a reason",
+            "END": "blocked under a strict policy, or out of revisions",
         },
     },
     "N1_5_revise_test_plan": {
@@ -82,7 +83,8 @@ ATLAS: dict[str, dict] = {
         ),
         "successors": {
             "N2_5_validate_tests": "tests were generated",
-            "END": "scaffolding failed, or this was a scaffold-only run",
+            "HALT": "scaffolding failed",
+            "END": "this was a scaffold-only run, which is a finish",
         },
     },
     "N2_5_validate_tests": {
@@ -104,7 +106,8 @@ ATLAS: dict[str, dict] = {
             # having skipped the red phase. The edge is in the compiled graph
             # and is named here so the drift guard stays honest about it.
             "N4_implement_code": "never taken; the edge #2331 stopped using",
-            "END": "still unusable when the attempt budget is spent",
+            "HALT": "still unusable when the attempt budget is spent",
+            "END": "the node returned no reason to record",
         },
     },
     "N3_verify_red": {
@@ -120,7 +123,8 @@ ATLAS: dict[str, dict] = {
             "N4_implement_code": "the tests fail, as they must",
             "N5_verify_green": "the work is already done (#2337)",
             "N2_scaffold_tests": "the suite is broken; scaffold again",
-            "END": "the tests pass without code, or the runner is unusable",
+            "HALT": "the tests pass without code, or the runner is unusable",
+            "END": "the node returned no reason to record",
         },
     },
     "N4_implement_code": {
@@ -134,7 +138,7 @@ ATLAS: dict[str, dict] = {
         ),
         "successors": {
             "N4b_completeness_gate": "the files were written",
-            "END": "the implementer could not produce usable code",
+            "HALT": "the implementer could not produce usable code",
         },
     },
     "N4b_completeness_gate": {
@@ -149,7 +153,9 @@ ATLAS: dict[str, dict] = {
         "successors": {
             "N5_verify_green": "every requirement has code",
             "N4_implement_code": "something is missing; implement it",
-            "END": "still incomplete at the iteration cap",
+            "HALT": "the gate itself failed and left a reason",
+            "END": "still incomplete at the iteration cap; the orchestrator "
+                   "reads the BLOCK verdict (#1779)",
         },
     },
     "N4c_augment_tests": {
@@ -181,7 +187,8 @@ ATLAS: dict[str, dict] = {
             "N4_implement_code": "still failing; implement again",
             "N4c_augment_tests": "green but under-covered; add tests (#2327)",
             "N2_scaffold_tests": "the suite itself is the problem",
-            "END": "the iteration cap, the circuit breaker, or a dead runner",
+            "HALT": "the iteration cap, the circuit breaker, or a dead runner",
+            "END": "the node returned no reason to record",
         },
     },
     "N6_e2e_validation": {
@@ -196,7 +203,8 @@ ATLAS: dict[str, dict] = {
         "successors": {
             "N7_finalize": "validated, or not applicable",
             "N4_implement_code": "the feature does not work; implement again",
-            "END": "the e2e cap, the circuit breaker, or an e2e error",
+            "HALT": "the circuit breaker, or an e2e error with a reason",
+            "END": "the e2e iteration cap, which records no reason",
         },
     },
     "N7_finalize": {
@@ -211,7 +219,8 @@ ATLAS: dict[str, dict] = {
         ),
         "successors": {
             "N7_5_adversarial": "finalized",
-            "END": "finalizing failed, or documentation is being skipped",
+            "HALT": "finalizing failed",
+            "END": "documentation is being skipped, which is a finish",
         },
     },
     "N7_5_adversarial": {
@@ -259,14 +268,16 @@ ATLAS: dict[str, dict] = {
         "ordinal": None,
         "goal": "Record why the run stopped, then end it cleanly.",
         "teach": (
-            "Declared but unreachable in THIS graph, unlike its counterparts "
-            "in the requirements and implementation-spec workflows. No router "
-            "here returns HALT: every stop routes straight to END carrying an "
-            "`error_message`, which the orchestrator relays. The node and its "
-            "outbound edge are dead code, and `successors` is empty because "
-            "the compiled graph has no edge out of it. Filed as its own issue "
-            "rather than deleted here, since removing a node is a ruling."
+            "Reachable since #2756, from all ten routers that can carry an "
+            "`error_message`. Before that it was declared and stranded: every "
+            "stop routed straight to END and the orchestrator relayed the "
+            "message, so implementation-stage halts never passed through the "
+            "node that writes the halt bundle -- the artifact carrying the "
+            "gate key, the outstanding work and the resume line. An exit, "
+            "never a step, so it takes no ordinal."
         ),
-        "successors": {},
+        "successors": {
+            "END": "always -- the reason is recorded, the run is over",
+        },
     },
 }

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -132,24 +132,24 @@ def _wrap_with_checkpoint(node_fn: Callable[..., dict[str, Any]],
 
 def route_after_load(
     state: TestingWorkflowState,
-) -> Literal["N1_review_test_plan", "end"]:
+) -> Literal["N1_review_test_plan", "HALT"]:
     """Route after N0 (load_lld).
 
     Args:
         state: Current workflow state.
 
     Returns:
-        Next node name or END.
+        Next node name, or HALT when the node recorded a reason (#2756).
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
     return "N1_review_test_plan"
 
 
 def route_after_review(
     state: TestingWorkflowState,
-) -> Literal["N2_scaffold_tests", "N1_5_revise_test_plan", "end"]:
+) -> Literal["N2_scaffold_tests", "N1_5_revise_test_plan", "end", "HALT"]:
     """Route after N1 (review_test_plan).
 
     Issue #1072: BLOCKED no longer terminates by default. The
@@ -181,7 +181,7 @@ def route_after_review(
     revision_count = state.get("test_plan_revision_count", 0)
 
     if error and not auto_mode:
-        return "end"
+        return "HALT"
 
     if test_plan_status == "BLOCKED":
         # Legacy auto_mode flag OR policy=auto bypasses the gate.
@@ -215,7 +215,7 @@ def route_after_review(
 
 def route_after_scaffold(
     state: TestingWorkflowState,
-) -> Literal["N2_5_validate_tests", "end"]:
+) -> Literal["N2_5_validate_tests", "end", "HALT"]:
     """Route after N2 (scaffold_tests).
 
     Issue #335: Updated to route to validation node instead of verify_red.
@@ -224,13 +224,15 @@ def route_after_scaffold(
         state: Current workflow state.
 
     Returns:
-        Next node name or END.
+        Next node name, END for a scaffold-only run, or HALT when the node
+        recorded a reason (#2756).
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
 
-    # scaffold_only mode - stop after scaffolding
+    # scaffold_only mode - stop after scaffolding. A finish, not a halt:
+    # nothing failed and there is no reason to record (#2756).
     if state.get("scaffold_only"):
         return "end"
 
@@ -239,7 +241,7 @@ def route_after_scaffold(
 
 def route_after_validate(
     state: TestingWorkflowState,
-) -> Literal["N3_verify_red", "N2_scaffold_tests", "end"]:
+) -> Literal["N3_verify_red", "N2_scaffold_tests", "end", "HALT"]:
     """Route after N2.5 (validate_tests_mechanical).
 
     Issue #335: Routes based on test validation results.
@@ -269,7 +271,7 @@ def route_after_validate(
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
 
     # Use the should_regenerate function from validate_tests_mechanical
     decision = should_regenerate(state)
@@ -285,7 +287,7 @@ def route_after_validate(
 def route_after_red(
     state: TestingWorkflowState,
 ) -> Literal[
-    "N4_implement_code", "N2_scaffold_tests", "N5_verify_green", "end",
+    "N4_implement_code", "N2_scaffold_tests", "N5_verify_green", "end", "HALT",
 ]:
     """Route after N3 (verify_red_phase).
 
@@ -295,13 +297,13 @@ def route_after_red(
         state: Current workflow state.
 
     Returns:
-        Next node name or END.
+        Next node name, or HALT when the node recorded a reason (#2756).
     """
     error = state.get("error_message", "")
     next_node = state.get("next_node", "")
 
     if error:
-        return "end"
+        return "HALT"
 
     if next_node == "N4_implement_code":
         return "N4_implement_code"
@@ -321,7 +323,7 @@ def route_after_red(
 
 def route_after_implement(
     state: TestingWorkflowState,
-) -> Literal["N4b_completeness_gate", "end"]:
+) -> Literal["N4b_completeness_gate", "HALT"]:
     """Route after N4 (implement_code).
 
     Issue #147: Routes to N4b completeness gate instead of directly to N5.
@@ -330,11 +332,11 @@ def route_after_implement(
         state: Current workflow state.
 
     Returns:
-        Next node name or END.
+        Next node name, or HALT when the node recorded a reason (#2756).
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
     return "N4b_completeness_gate"
 
 
@@ -349,7 +351,7 @@ def route_after_green(
     state: TestingWorkflowState,
 ) -> Literal[
     "N6_e2e_validation", "N7_finalize", "N4_implement_code",
-    "N4c_augment_tests", "N2_scaffold_tests", "end",
+    "N4c_augment_tests", "N2_scaffold_tests", "end", "HALT",
 ]:
     """Route after N5 (verify_green_phase).
 
@@ -359,13 +361,13 @@ def route_after_green(
         state: Current workflow state.
 
     Returns:
-        Next node name or END.
+        Next node name, or HALT when the node recorded a reason (#2756).
     """
     error = state.get("error_message", "")
     next_node = state.get("next_node", "")
 
     if error:
-        return "end"
+        return "HALT"
 
     # Issue #292: Exit code 4/5 routes back to scaffold
     if next_node == "N2_scaffold_tests":
@@ -434,7 +436,7 @@ def route_after_green(
 
 def route_after_e2e(
     state: TestingWorkflowState,
-) -> Literal["N7_finalize", "N4_implement_code", "end"]:
+) -> Literal["N7_finalize", "N4_implement_code", "end", "HALT"]:
     """Route after N6 (e2e_validation).
 
     Args:
@@ -447,7 +449,7 @@ def route_after_e2e(
     next_node = state.get("next_node", "")
 
     if error:
-        return "end"
+        return "HALT"
 
     # E2E failure may loop back to implement
     if next_node == "N4_implement_code":
@@ -462,7 +464,7 @@ def route_after_e2e(
 
 def route_after_finalize(
     state: TestingWorkflowState,
-) -> Literal["N7_5_adversarial", "end"]:
+) -> Literal["N7_5_adversarial", "end", "HALT"]:
     """Route after N7 (finalize).
 
     Issue #352: Now routes to adversarial node instead of directly to N8.
@@ -475,9 +477,9 @@ def route_after_finalize(
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
 
-    # Skip documentation if flag is set
+    # Skip documentation if flag is set. A finish, not a halt (#2756).
     if state.get("skip_docs"):
         return "end"
 
@@ -564,7 +566,10 @@ def build_testing_workflow() -> StateGraph:
         route_after_load,
         {
             "N1_review_test_plan": "N1_review_test_plan",
-            "end": END,
+            # #2756: no "end" -- this router's only stop is an error, and it
+            # now goes to HALT. Leaving the entry would declare an edge
+            # nothing can take, which is the defect this issue is about.
+            "HALT": "HALT",
         },
     )
 
@@ -576,6 +581,7 @@ def build_testing_workflow() -> StateGraph:
             "N2_scaffold_tests": "N2_scaffold_tests",
             "N1_5_revise_test_plan": "N1_5_revise_test_plan",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -589,6 +595,7 @@ def build_testing_workflow() -> StateGraph:
         {
             "N2_5_validate_tests": "N2_5_validate_tests",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -601,6 +608,7 @@ def build_testing_workflow() -> StateGraph:
             "N2_scaffold_tests": "N2_scaffold_tests",
             "N4_implement_code": "N4_implement_code",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -613,6 +621,7 @@ def build_testing_workflow() -> StateGraph:
             "N5_verify_green": "N5_verify_green",  # #2337
             "N2_scaffold_tests": "N2_scaffold_tests",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -622,7 +631,8 @@ def build_testing_workflow() -> StateGraph:
         route_after_implement,
         {
             "N4b_completeness_gate": "N4b_completeness_gate",
-            "end": END,
+            # #2756: no "end" -- see route_after_load.
+            "HALT": "HALT",
         },
     )
 
@@ -634,6 +644,7 @@ def build_testing_workflow() -> StateGraph:
             "N5_verify_green": "N5_verify_green",
             "N4_implement_code": "N4_implement_code",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -648,6 +659,7 @@ def build_testing_workflow() -> StateGraph:
             "N4c_augment_tests": "N4c_augment_tests",  # #2327
             "N2_scaffold_tests": "N2_scaffold_tests",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -664,6 +676,7 @@ def build_testing_workflow() -> StateGraph:
             "N7_finalize": "N7_finalize",
             "N4_implement_code": "N4_implement_code",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 
@@ -674,6 +687,7 @@ def build_testing_workflow() -> StateGraph:
         {
             "N7_5_adversarial": "N7_5_adversarial",
             "end": END,
+            "HALT": "HALT",  # #2756
         },
     )
 

--- a/assemblyzero/workflows/testing/nodes/completeness_gate.py
+++ b/assemblyzero/workflows/testing/nodes/completeness_gate.py
@@ -325,7 +325,7 @@ def _completeness_issue_identity(issue: dict) -> tuple:
 
 def route_after_completeness_gate(
     state: TestingWorkflowState,
-) -> Literal["N5_verify_green", "N4_implement_code", "end"]:
+) -> Literal["N5_verify_green", "N4_implement_code", "end", "HALT"]:
     """Route based on completeness verdict and iteration count.
 
     Issue #147, Requirements 7, 8, 12:
@@ -336,15 +336,21 @@ def route_after_completeness_gate(
     Issue #505: AST stagnation detection — identical issues across
     2 consecutive iterations routes to end immediately.
 
+    #2756: a node that recorded a reason routes to HALT, so the stop is
+    written down by the node that owns halting. The verdict-driven stops
+    below keep going to END: they carry no `error_message`, and the
+    orchestrator reads the BLOCK verdict itself (#1779).
+
     Args:
         state: Current workflow state with completeness_verdict set.
 
     Returns:
-        Next node name: "N5_verify_green", "N4_implement_code", or "end".
+        Next node name: "N5_verify_green", "N4_implement_code", "end", or
+        "HALT".
     """
     error = state.get("error_message", "")
     if error:
-        return "end"
+        return "HALT"
 
     verdict = state.get("completeness_verdict", "")
     iteration_count = state.get("iteration_count", 0)

--- a/tests/unit/test_completeness_gate.py
+++ b/tests/unit/test_completeness_gate.py
@@ -782,14 +782,14 @@ class TestCompletenessGateRouting:
         assert result == "end"
 
     def test_error_message_routes_to_end(self, mock_state) -> None:
-        """Error message in state routes to end regardless of verdict."""
+        """A recorded reason routes to HALT regardless of verdict (#2756)."""
         state = mock_state(
             completeness_verdict="PASS",
             iteration_count=0,
             error_message="Something went wrong",
         )
         result = route_after_completeness_gate(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_max_iterations_constant_is_three(self) -> None:
         """Verify MAX_COMPLETENESS_ITERATIONS is 3 per LLD spec."""

--- a/tests/unit/test_exit_code_verify_phases.py
+++ b/tests/unit/test_exit_code_verify_phases.py
@@ -339,9 +339,9 @@ class TestGraphRoutingWithExitCodes:
         assert route_after_red(state) == "N4_implement_code"
 
     def test_route_after_red_error(self):
-        """route_after_red returns end on error."""
+        """route_after_red returns HALT on a recorded reason (#2756)."""
         state = {"error_message": "some error", "next_node": "N4_implement_code"}
-        assert route_after_red(state) == "end"
+        assert route_after_red(state) == "HALT"
 
     def test_route_after_green_scaffold(self):
         """route_after_green returns N2_scaffold_tests when next_node says so."""
@@ -369,6 +369,6 @@ class TestGraphRoutingWithExitCodes:
         assert route_after_green(state) == "N7_finalize"
 
     def test_route_after_green_error(self):
-        """route_after_green returns end on error."""
+        """route_after_green returns HALT on a recorded reason (#2756)."""
         state = {"error_message": "boom", "next_node": "N4_implement_code"}
-        assert route_after_green(state) == "end"
+        assert route_after_green(state) == "HALT"

--- a/tests/unit/test_red_phase_retry_semantics.py
+++ b/tests/unit/test_red_phase_retry_semantics.py
@@ -182,4 +182,4 @@ def test_existing_routes_are_unchanged(next_node: str, expected: str) -> None:
 def test_an_error_still_ends_regardless() -> None:
     assert route_after_red(
         {"error_message": "boom", "next_node": "N5_verify_green"}
-    ) == "end"
+    ) == "HALT"  # #2756: the stop is recorded, not just taken

--- a/tests/unit/test_revise_test_plan.py
+++ b/tests/unit/test_revise_test_plan.py
@@ -86,14 +86,19 @@ def test_route_approved_goes_straight_to_scaffold_regardless_of_policy():
         assert route_after_review(state) == "N2_scaffold_tests"
 
 
-def test_route_error_with_no_auto_mode_ends():
-    """error_message + auto_mode=False → end (preserves prior behavior)."""
+def test_route_error_with_no_auto_mode_halts():
+    """error_message + auto_mode=False → HALT (#2756).
+
+    Still a stop; the destination changed so the reason is written down by
+    the node that owns halting. The two policy stops above keep going to END:
+    they carry no error_message, so there is nothing to record.
+    """
     state: dict[str, Any] = {
         "error_message": "something blew up",
         "test_plan_status": "PENDING",
         "auto_mode": False,
     }
-    assert route_after_review(state) == "end"
+    assert route_after_review(state) == "HALT"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_testing_graph_halts_through_halt.py
+++ b/tests/unit/test_testing_graph_halts_through_halt.py
@@ -1,0 +1,170 @@
+"""An implementation-stage halt goes through the node that owns halting (#2756).
+
+The testing graph declared a `HALT` node and nothing routed to it. Every stop
+went straight to `END` carrying an `error_message`, which the orchestrator
+relayed — so halting worked, and the node built to write the halt bundle never
+ran. `create_halt_node` is what produces that bundle: the gate key, the work
+still outstanding, and the command to resume, which #2725 spent a PR making
+findable.
+
+The acceptance is the bundle, not the routing: a halted roll of the REAL
+compiled graph has to leave one on disk, with the same three things #2735
+asserts for the other two graphs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assemblyzero.core.halt_node as hn
+import assemblyzero.core.state_persistence as sp
+from assemblyzero.workflows.testing.graph import (
+    build_testing_workflow,
+    route_after_green,
+    route_after_implement,
+    route_after_load,
+    route_after_scaffold,
+)
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    """Redirect the halt's snapshot away from the real state directory.
+
+    Patched on BOTH modules: `halt_node` imports `STATE_DIR` by value, and
+    `save_state_snapshot` reads it from `state_persistence`.
+    """
+    target = tmp_path / "state"
+    target.mkdir()
+    monkeypatch.setattr(hn, "STATE_DIR", target, raising=False)
+    monkeypatch.setattr(sp, "STATE_DIR", target, raising=False)
+    return target
+
+
+def _bundles(root: Path) -> list[Path]:
+    return sorted(root.rglob("halt-evidence.json"))
+
+
+class TestTheGraphReachesHalt:
+    """The wiring, measured against the compiled graph rather than the source."""
+
+    def test_halt_has_inbound_edges_now(self):
+        graph = build_testing_workflow().compile().get_graph()
+        inbound = sorted(e.source for e in graph.edges if e.target == "HALT")
+        assert inbound, (
+            "HALT has no inbound edge: the node that writes the halt bundle "
+            "is stranded again (#2756)"
+        )
+        # Every router that can carry an error_message reaches it.
+        assert set(inbound) == {
+            "N0_load_lld",
+            "N1_review_test_plan",
+            "N2_scaffold_tests",
+            "N2_5_validate_tests",
+            "N3_verify_red",
+            "N4_implement_code",
+            "N4b_completeness_gate",
+            "N5_verify_green",
+            "N6_e2e_validation",
+            "N7_finalize",
+        }, inbound
+
+    def test_halt_still_ends_the_run(self):
+        graph = build_testing_workflow().compile().get_graph()
+        assert [e.target for e in graph.edges if e.source == "HALT"] == ["__end__"]
+
+    def test_a_recorded_reason_routes_to_halt_and_a_clean_finish_does_not(self):
+        """The distinction the whole change rests on. `error_message` is the
+        walker's own definition of a halt site, so routing on it is what makes
+        the set of stops that reach HALT the set of registered halts."""
+        assert route_after_load({"error_message": "boom"}) == "HALT"
+        assert route_after_load({}) == "N1_review_test_plan"
+
+        assert route_after_implement({"error_message": "boom"}) == "HALT"
+        assert route_after_implement({}) == "N4b_completeness_gate"
+
+        # A scaffold-only run finished; it did not fail, and there is no
+        # reason to record. It must NOT produce a halt bundle.
+        assert route_after_scaffold({"scaffold_only": True}) == "end"
+        assert route_after_scaffold({"error_message": "boom"}) == "HALT"
+
+        assert route_after_green({"error_message": "boom"}) == "HALT"
+
+
+class TestAHaltedRollLeavesABundle:
+    """#2735's three things, for this graph."""
+
+    @pytest.fixture
+    def halted(self, state_dir, tmp_path, monkeypatch):
+        """Roll the real compiled graph to a halt at N0.
+
+        N0 is the cheapest true halt in the graph -- no model call, no repo,
+        no test run -- and it exercises the same wiring every other halt now
+        uses, because they all reach HALT the same way.
+        """
+        audit = tmp_path / "lineage"
+        audit.mkdir()
+        (audit / "001-spec-draft.md").write_text("# Spec\n", encoding="utf-8")
+
+        app = build_testing_workflow().compile()
+        result = app.invoke({
+            "issue_number": 4242,
+            # No spec_path and no lld_content: load_lld records a reason.
+            "spec_path": str(tmp_path / "does-not-exist.md"),
+            "worktree_path": str(tmp_path),
+            "repo_root": str(tmp_path),
+            "audit_dir": str(audit),
+            "max_iterations": 1,
+        })
+        return result, audit
+
+    def test_the_roll_actually_halted(self, halted):
+        result, _ = halted
+        assert result.get("error_message"), (
+            "the fixture did not reach a halt, so nothing below is evidence"
+        )
+
+    def test_the_halt_node_ran(self, halted):
+        """`recovery_plan_path` is returned by `create_halt_node` and by
+        nothing else, so its presence is proof the node executed rather than
+        the run ending at END the way it did before #2756."""
+        result, _ = halted
+        assert result.get("recovery_plan_path"), (
+            "no recovery plan: the run ended without passing through HALT"
+        )
+
+    def test_a_bundle_landed_in_the_audit_dir(self, halted):
+        _, audit = halted
+        assert (audit / "halt-evidence.json").is_file()
+        assert (audit / "halt-evidence.md").is_file()
+
+    def test_the_bundle_carries_the_gate_key_outstanding_and_resume(self, halted):
+        _, audit = halted
+        evidence = json.loads(
+            (audit / "halt-evidence.json").read_text(encoding="utf-8")
+        )
+        assert evidence.get("gate_key"), "no gate key: the bundle cannot be joined"
+        assert "outstanding" in evidence
+        assert evidence.get("resume_command"), "no way back in"
+
+        rendered = (audit / "halt-evidence.md").read_text(encoding="utf-8")
+        assert "Gate: `" in rendered
+        assert "## Resume" in rendered
+
+    def test_the_bundle_is_not_written_over_the_shared_state_dir(
+        self, halted, state_dir
+    ):
+        """#2725's finding, which this change could have re-created by
+        multiplying the number of halts that write one: the copy beside the
+        snapshot goes in a directory named for the halt, not straight into the
+        state dir, which is global across every repo the fleet has rolled."""
+        _, _audit = halted
+        loose = state_dir / "halt-evidence.json"
+        assert not loose.exists(), (
+            "the bundle was written straight into the shared state directory, "
+            "where the next halt of any repo overwrites it"
+        )
+        assert _bundles(state_dir), "no bundle beside the state snapshot at all"

--- a/tests/unit/test_testing_workflow.py
+++ b/tests/unit/test_testing_workflow.py
@@ -2387,14 +2387,14 @@ class TestGraphRoutingFunctions:
     """Tests for graph.py routing functions."""
 
     def test_route_after_load_error(self, tmp_path):
-        """route_after_load returns end on error."""
+        """route_after_load returns HALT on a recorded reason (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_load
 
         state: TestingWorkflowState = {
             "error_message": "Some error",
         }
         result = route_after_load(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_route_after_load_success(self, tmp_path):
         """route_after_load continues on success."""
@@ -2418,14 +2418,14 @@ class TestGraphRoutingFunctions:
         assert result == "end"
 
     def test_route_after_red_error(self, tmp_path):
-        """route_after_red returns end on error."""
+        """route_after_red returns HALT on a recorded reason (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_red
 
         state: TestingWorkflowState = {
             "error_message": "Tests failed",
         }
         result = route_after_red(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_route_after_red_success(self, tmp_path):
         """route_after_red continues to implement."""
@@ -2450,14 +2450,14 @@ class TestGraphRoutingFunctions:
         assert result == "end"
 
     def test_route_after_implement_error(self, tmp_path):
-        """route_after_implement returns end on error."""
+        """route_after_implement returns HALT on a recorded reason (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_implement
 
         state: TestingWorkflowState = {
             "error_message": "Implementation failed",
         }
         result = route_after_implement(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_route_after_green_iteration_max(self, tmp_path):
         """route_after_green returns end at max iterations."""
@@ -3409,7 +3409,7 @@ class TestGraphRoutingEdgeCases:
     """Additional tests for graph.py routing edge cases."""
 
     def test_route_after_review_error_without_auto(self):
-        """route_after_review returns end on error without auto mode."""
+        """route_after_review returns HALT on a reason, no auto mode (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_review
 
         state: TestingWorkflowState = {
@@ -3418,7 +3418,7 @@ class TestGraphRoutingEdgeCases:
             "test_plan_status": "APPROVED",
         }
         result = route_after_review(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_route_after_green_no_next_node(self):
         """route_after_green returns end when no next_node."""
@@ -3432,24 +3432,24 @@ class TestGraphRoutingEdgeCases:
         assert result == "end"
 
     def test_route_after_e2e_error(self):
-        """route_after_e2e returns end on error."""
+        """route_after_e2e returns HALT on a recorded reason (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_e2e
 
         state: TestingWorkflowState = {
             "error_message": "E2E failed",
         }
         result = route_after_e2e(state)
-        assert result == "end"
+        assert result == "HALT"
 
     def test_route_after_finalize_error(self):
-        """route_after_finalize returns end on error."""
+        """route_after_finalize returns HALT on a recorded reason (#2756)."""
         from assemblyzero.workflows.testing.graph import route_after_finalize
 
         state: TestingWorkflowState = {
             "error_message": "Finalize error",
         }
         result = route_after_finalize(state)
-        assert result == "end"
+        assert result == "HALT"
 
 
 class TestTemplatesFullCoverage:


### PR DESCRIPTION
Ranked item 6. The issue offered three options and the instruction was to take the middle one: wire it.

## What was wrong

`assemblyzero/workflows/testing/graph.py` declared a `HALT` node and an edge from it to `END`, and no router ever returned `"HALT"`. Every stop in the implementation stage went straight to `END` carrying an `error_message`, which the orchestrator relayed.

So halting worked. What never ran was `create_halt_node` — the thing that writes the **halt bundle**: the gate key, the work still outstanding when the run stopped, and the command to resume. #2725 spent a PR making that artifact findable, and implementation-stage halts were not producing one by the path the other two stages use.

## The rule, and why it is not arbitrary

Ten routers now return `"HALT"` where they returned `"end"`, and the ten edge maps gained the destination. The condition is a non-empty `error_message`.

That is the **walker's own definition of a halt site** — `scan_halt_sites` finds a halt by looking for a return with a non-empty `error_message`. So the set of stops that now reach HALT is exactly the set of halts the gate registry knows about. Not a judgement call per branch; the same predicate the registry is built on.

Stops carrying no reason keep going to `END`, because there is nothing to record and a bundle for them would be noise:

| stop | why it is not a halt |
|---|---|
| scaffold-only run | a finish — the run did what it was asked |
| skip-docs at finalize | a finish |
| BLOCKED plan under a strict policy | no reason recorded |
| completeness gate BLOCK at its cap | the orchestrator reads the verdict (#1779) |
| e2e iteration cap | no reason recorded |

`route_after_load` and `route_after_implement` lost their `"end"` entry entirely: their only stop is an error, so leaving it would declare an edge nothing can take — which is the defect this issue is about.

## Measured against the compiled graph

Not read off the source, because the issue's own numbers came from the compiled form:

- **inbound edges to `HALT`: 0 → 10** (`N0`, `N1`, `N2`, `N2.5`, `N3`, `N4`, `N4b`, `N5`, `N6`, `N7`)
- outbound `HALT -> __end__`: intact
- ratchet unchanged: **147 halt sites, 94 gates, impl 34** — wiring changes where a stop goes, not how many places can stop

The atlas described `HALT` as unreachable with an empty `successors` map — "a room with no doors", as the issue put it. It now names the edge, and each of the ten nodes that can reach it says so. The drift guard in `test_graph_atlas.py` is what forced every one of those descriptions to be accurate, and it caught the first attempt.

## Acceptance

`tests/unit/test_testing_graph_halts_through_halt.py`, 8 tests. The core one rolls the **real compiled graph** to a halt and asserts the bundle carries the same three things #2735 asserts for the other two graphs — gate key, outstanding list, resume command — in both the JSON and the rendered markdown. `recovery_plan_path` in the result is the proof the node actually executed, since nothing else returns it.

One test guards against the failure this change could most easily have re-created: #2725 found that the copy beside the state snapshot was landing loose in the shared state directory, which is global across every repo the fleet has ever rolled, so each halt overwrote the last. Multiplying the number of halts that write a bundle makes that worse if it regresses, so it is now asserted.

## The eleven assertions that moved

Eleven existing tests asserted a router returns `"end"` on an error. Each now asserts `"HALT"`. Every one of them is asserting *that an error stops the run*, which is still true — only the destination changed.

The neighbouring assertions on no-error paths were deliberately left alone, and that separation is the whole correctness argument: `test_route_after_green_no_next_node` and the two policy stops in `test_revise_test_plan.py` sit inches away in the same files and still expect `"end"`.

## Verification

- Full unit suite: see the check on this PR. Locally the affected files run 440 passed.
- `tools/audit_halt_sites.py --check`: PASS, unchanged.
- `ruff check` clean on all four changed source files.

Not done here: nothing about this changes which stops *exist*, so the routing policy's counts are untouched. The issue's closing observation — that two independent unreachable-thing findings argue for a reachability test rather than someone noticing — is partly addressed by the guard #2792 added for registry rows, and the remaining gap (a node module with no rows at all) is #2791.

Closes #2756
