### PR TITLE
fix: tell the three DETERMINISTIC FAILURE gates apart in the report (Closes #2794)

### DIFF
--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -301,12 +301,34 @@ CAUSE_TABLE: tuple[Cause, ...] = (
         "carries 1 commit(s)",
         "already exists and carries",
     ),
+    # #2761: three gates emit the DETERMINISTIC_FAILURE token, and until
+    # 2026-09-04 one generic row swallowed all of them. Measured over
+    # boostgauge's runs/, the four runs that died carrying it were:
+    # run-issue384 and run-issue4 on the scaffolder's suite-invalid halt, and
+    # run-issue331 and run-issue379 on the red phase -- so HALF of
+    # `impl.deterministic_failure`'s recorded kills belonged to a different
+    # row, which the registry's own note already said was a different gate.
+    #
+    # The tell was in the table itself: the generic row's `example` was the
+    # scaffolder's message, so the row was documented, and its own test
+    # pinned, against a gate it is not. Specific rows first -- `classify_cause`
+    # takes the first match.
     Cause(
-        "impl.deterministic_failure", r"DETERMINISTIC FAILURE",
-        "assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py", "model_output",
+        "impl.scaffold_suite_invalid",
+        r"DETERMINISTIC FAILURE: the generated test suite cannot be",
+        "assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py",
+        "upstream_artifact",
         "DETERMINISTIC FAILURE: the generated test suite cannot be validated "
         "and the scaffolder",
-        "DETERMINISTIC FAILURE",
+        "the generated test suite cannot be",
+    ),
+    Cause(
+        "impl.deterministic_failure", r"DETERMINISTIC FAILURE",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "DETERMINISTIC FAILURE: Red phase failed: 3 tests passed "
+        "unexpectedly, and neither a red-entry marker nor this run's own "
+        "prior writes explain them",
+        "tests passed unexpectedly, and neither a red-entry marker",
     ),
     Cause(
         "impl.red_phase_failed", r"Red phase failed",

--- a/tests/unit/test_factory_report.py
+++ b/tests/unit/test_factory_report.py
@@ -634,6 +634,43 @@ class TestCauseTable:
         keys = [cause.key for cause in CAUSE_TABLE]
         assert len(keys) == len(set(keys))
 
+    def test_the_three_deterministic_failures_are_told_apart(self):
+        """#2761: one generic row swallowed three gates.
+
+        `DETERMINISTIC_FAILURE` is a token three different halts prepend, and
+        a single `r"DETERMINISTIC FAILURE"` row claimed every one. Measured on
+        boostgauge before this split, `impl.deterministic_failure` was
+        credited with 5 kills; 3 of them were the scaffolder's suite-invalid
+        halt, which the gate registry's own note already called a different
+        gate.
+
+        The tell was inside the table: that row's `example` was the
+        scaffolder's message, so the row was documented -- and
+        `test_every_row_matches_its_own_example` pinned -- against a gate it
+        is not. Both of these are real banner heads from the run logs.
+        """
+        scaffolder = (
+            "DETERMINISTIC FAILURE: the generated test suite cannot be "
+            "validated and the scaffolder reproduced its previous output"
+        )
+        red_phase = (
+            "DETERMINISTIC FAILURE: Red phase failed: 3 tests passed "
+            "unexpectedly, and neither a red-entry marker nor this run's own "
+            "prior writes explain them"
+        )
+        assert classify_cause(scaffolder) == "impl.scaffold_suite_invalid"
+        assert classify_cause(red_phase) == "impl.deterministic_failure"
+
+    def test_a_specific_cause_row_precedes_the_generic_one_it_shares_a_prefix_with(
+        self,
+    ):
+        """Order is load-bearing: `classify_cause` takes the FIRST match, so a
+        specific row placed after its generic sibling can never fire."""
+        keys = [cause.key for cause in CAUSE_TABLE]
+        assert keys.index("impl.scaffold_suite_invalid") < keys.index(
+            "impl.deterministic_failure"
+        )
+
     def test_every_row_names_code_that_says_what_the_row_claims(self):
         for cause in CAUSE_TABLE:
             path = REPO_ROOT / cause.emitted_by


### PR DESCRIPTION
Found while working #2761 (ranked item 7), split out because it needs no ruling and #2761 cannot close on it. #2761 is about splitting a **registry row**; this is about the **report** crediting kills to the wrong gate.

## Three gates, one cause row

`DETERMINISTIC_FAILURE` is a token three different halts prepend. The cause table had one generic row claiming all of them — and its `example` field, the thing `test_every_row_matches_its_own_example` pins, was a **different gate's message**:

```python
Cause(
    "impl.deterministic_failure", r"DETERMINISTIC FAILURE",
    ".../validate_tests_mechanical.py", "model_output",
    "DETERMINISTIC FAILURE: the generated test suite cannot be validated "
    "and the scaffolder",          # <- impl.scaffold_suite_invalid's message
    "DETERMINISTIC FAILURE",
),
```

The check passed because the row's pattern is broad enough to match another gate's message, which is precisely the failure that check exists to catch.

## Measured, every run carrying the token

| run | what actually killed it |
|---|---|
| `run-issue384` | the scaffolder's suite-invalid halt — `impl.scaffold_suite_invalid` |
| `run-issue4` | the same |
| `run-issue331` | the red phase, pre-#2337 message |
| `run-issue379` | the red phase, current message |

`impl.scaffold_suite_invalid` had **no cause row at all**, so its deaths were absorbed by a neighbour. The gate registry already knew: its note on the generic row reads *"the scaffolder's suite-invalid halt shares the prefix and is impl.scaffold_suite_invalid."*

## Counted over all 180 run logs, before → after

| | before | after |
|---|---|---|
| `impl.deterministic_failure` | 5 kills | **2** |
| `impl.scaffold_suite_invalid` | 0 (no row) | **3** |
| by judges: `model_output` | 32 | **29** |
| by judges: `upstream_artifact` | 1 | **4** |

135 failed runs classified both times, nothing unclassified.

## Why it matters beyond tidiness

`judges` is the column the routing policy reads. Three kills sat under `model_output` that belong under `upstream_artifact`, so the report **overstated how often a gate judging the drafter's own output ended a run** — the number #2723 is being measured by.

It also hid a gate: anyone asking what `impl.scaffold_suite_invalid` costs got zero, because its deaths were filed elsewhere.

Same shape as #2784, where a credentials outage is filed as an edit-script rejection.

## What landed

A specific row for `impl.scaffold_suite_invalid`, ordered **before** the generic one — `classify_cause` takes the first match, so a specific row placed after its generic sibling can never fire. The generic row's `example`, `emitted_by` and `source_literal` now name its own gate in `verify_phases.py`.

Two tests: one classifying both real banner heads to the right keys, one asserting the ordering, because the ordering is what makes it work.

## Not done: #2761's registry split

**#2761 stays open.** The measurement changed its shape twice over. Most of the "the report cannot tell them apart" problem was this third gate, now fixed. The remaining two-readings problem is real, but **the code inverts the readings the issue describes**:

- the red-phase site fires when *"the implementation existed before this stage entered"* — a fact about the worktree, which reads as `infrastructure`, where the issue calls it a drafter defect;
- the green-phase site fires when *"The TEST is the wrong side here"* on a test N4c generated — which reads as `model_output`, where the issue calls it a fact about the machine. It has never fired.

Which way each half classifies decides whether the ratchet rises: both halves staying `model_output` takes the count 4 → 5 and `impl` 34 → 35, a rise no ruling covers, even though halt *sites* stay at 147 and no new place can stop a run. The question is on #2761 in one paragraph.

No registry change and no ratchet movement here: **4 model-output halt rows, 147 halt sites, 94 gates**, unchanged.

Closes #2794
