### PR TITLE
fix: count every regeneration, so a suite that collects nothing is rewritten (Closes #2767)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -681,8 +681,17 @@ GATE_REGISTRY: tuple[Gate, ...] = (
     Gate(
         "impl.red_phase_failed", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
         "Red phase failed",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 5)
-        + _s(f"{_TS}/nodes/verify_phases.py::_verify_red_non_pytest::return", 2, 3),
+        _s(f"{_TS}/nodes/verify_phases.py::_verify_red_non_pytest::return", 2),
+        justified_by="#2767",
+        notes=(
+            "one site left. #2767 (operator ruling 2026-09-04) turned the two "
+            "'no tests collected' sites -- one per framework path -- into a "
+            "bounded reroute to the scaffolder, so they record no reason and "
+            "are no longer halt sites. What remains is the non-pytest "
+            "unexpected-pass case, which #2337 fixed for pytest and never "
+            "ported; it is why this row still halts and the model-output "
+            "count is still 4 rather than 3"
+        ),
     ),
     Gate(
         "impl.green.collection_broken", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,

--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -615,8 +615,14 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
         if len(all_errors) > 5:
             print(f"      ... and {len(all_errors) - 5} more")
 
-    # Increment attempts if validation failed
-    new_attempts = scaffold_attempts + 1 if not is_valid else scaffold_attempts
+    # #2767 (operator ruling 2026-09-04): every pass through the scaffolder
+    # spends budget, not only the ones that fail validation. A budget that
+    # counts only failures is not a budget -- and it was the reason the
+    # `N3 -> N2` reroute (#292) had no bound of its own: a regenerated suite
+    # that passed validation incremented nothing, so the loop was held up
+    # only by LangGraph's default recursion limit, which has no gate key and
+    # no halt bundle.
+    new_attempts = scaffold_attempts + 1
 
     # Issue #500: Pass validation errors back so scaffold node can use them
     result_dict: dict[str, Any] = {
@@ -639,13 +645,18 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
     # spuriously exhausted, and the run ended silently as success
     # (run-issue384-044442 merged a PR with an assertion-free stub and no
     # code).
-    if not is_valid:
-        reason = _halt_if_exhausted(
-            state, result_dict, generated_tests, new_attempts, all_errors
-        )
-        result_dict["scaffold_route"] = "escalate" if reason else "regenerate"
+    #
+    # #2767: consulted on the VALID path too. A suite that validates and then
+    # collects nothing sends the red phase back here, and without this the
+    # cap it is supposedly bounded by was never read.
+    reason = _halt_if_exhausted(
+        state, result_dict, generated_tests, new_attempts, all_errors,
+        is_valid=is_valid,
+    )
+    if reason:
+        result_dict["scaffold_route"] = "escalate"
     else:
-        result_dict["scaffold_route"] = "continue"
+        result_dict["scaffold_route"] = "regenerate" if not is_valid else "continue"
 
     # Issue #502: Store hash for stagnation detection
     if generated_tests:
@@ -710,7 +721,7 @@ def _validate_non_pytest(
         for error in all_errors[:5]:
             print(f"      - {error}")
 
-    new_attempts = scaffold_attempts + 1 if not is_valid else scaffold_attempts
+    new_attempts = scaffold_attempts + 1  # #2767: every pass spends budget
 
     result: dict[str, Any] = {
         "validation_result": {
@@ -727,13 +738,15 @@ def _validate_non_pytest(
     # owes the same named halt. Leaving it out would make the defect a
     # property of the framework the run happens to use.
     # #2676: and it owes the same carried route, for the same reason.
-    if not is_valid:
-        reason = _halt_if_exhausted(
-            state, result, generated_tests, new_attempts, all_errors
-        )
-        result["scaffold_route"] = "escalate" if reason else "regenerate"
+    # #2767: and the same budget, consulted on the valid path too.
+    reason = _halt_if_exhausted(
+        state, result, generated_tests, new_attempts, all_errors,
+        is_valid=is_valid,
+    )
+    if reason:
+        result["scaffold_route"] = "escalate"
     else:
-        result["scaffold_route"] = "continue"
+        result["scaffold_route"] = "regenerate" if not is_valid else "continue"
     return result
 
 
@@ -743,7 +756,8 @@ def _validate_non_pytest(
 
 
 def exhausted_reason(
-    state: dict[str, Any], generated_tests: str, attempts: int
+    state: dict[str, Any], generated_tests: str, attempts: int,
+    *, is_valid: bool = False,
 ) -> str:
     """Why mechanical generation is out of moves, or "" while it is not.
 
@@ -752,6 +766,19 @@ def exhausted_reason(
     writes the halt message from it. When the two computed it separately they
     could disagree, and a route that ends a run whose state says nothing went
     wrong is the silent degradation this issue is about.
+
+    #2767: the threshold differs by path, and the asymmetry is deliberate.
+
+    An INVALID suite AT the cap is definitive -- three scaffolds, none of them
+    usable, and a fourth will not be different. That is `>=`, and it is the
+    behaviour that shipped.
+
+    A VALID suite at the cap is not. A run whose first two scaffolds failed
+    validation and whose third finally passed has produced exactly what was
+    asked for, and halting it at the moment it succeeded would make the retry
+    budget punish the retry it exists to allow. The valid path therefore stops
+    only once the count EXCEEDS the cap: the loop has already been round the
+    allowed number of times and is asking for one more.
     """
     if generated_tests:
         current = hashlib.sha256(generated_tests.encode()).hexdigest()
@@ -761,6 +788,15 @@ def exhausted_reason(
                 "the scaffolder reproduced its previous output byte for byte, "
                 "so regenerating again produces the same suite"
             )
+
+    if is_valid:
+        if attempts > MAX_SCAFFOLD_ATTEMPTS:
+            return (
+                f"the scaffolder has produced {attempts} suites, more than "
+                f"the limit of {MAX_SCAFFOLD_ATTEMPTS}, and the red phase "
+                f"still cannot use one"
+            )
+        return ""
 
     if attempts >= MAX_SCAFFOLD_ATTEMPTS:
         return (
@@ -777,6 +813,8 @@ def _halt_if_exhausted(
     generated_tests: str,
     attempts: int,
     errors: list[str],
+    *,
+    is_valid: bool = False,
 ) -> str:
     """Name the halt in state when regeneration cannot help, per #2331.
 
@@ -791,9 +829,25 @@ def _halt_if_exhausted(
     it, and the router reads the carried route instead of recomputing against
     the by-then-overwritten hash.
     """
-    reason = exhausted_reason(state, generated_tests, attempts)
+    reason = exhausted_reason(state, generated_tests, attempts, is_valid=is_valid)
     if not reason:
         return ""
+
+    if is_valid:
+        # #2767: the suite validated. Saying it "cannot be validated" would
+        # be false in the artifact a human reads to diagnose the halt -- the
+        # budget is what ran out, on a suite that passed every check this
+        # node makes and still sent the red phase back here.
+        result["error_message"] = (
+            f"{DETERMINISTIC_FAILURE}: the scaffold budget is spent and "
+            f"{reason}. The suite passed mechanical validation each time and "
+            f"the red phase still could not use it, so regenerating again "
+            f"asks the same question. Repair the spec's Section 10 test "
+            f"functions, then resume."
+        )
+        result["next_node"] = "end"
+        print(f"    [HALT] {result['error_message']}")
+        return reason
 
     shown = "; ".join(errors[:3]) if errors else "no specific error was recorded"
     result["error_message"] = (

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -1296,14 +1296,24 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
         }
 
     if total_red == 0:
-        print("    [GUARD] WARNING: No tests ran!")
-
+        # #2767 (operator ruling 2026-09-04): a suite that collects nothing is
+        # a suite to write again, not a run to end. The route back to the
+        # scaffolder already existed; what it lacked was a bound, and the same
+        # ruling gave it one -- the scaffold budget now counts every
+        # regeneration, so the third pass through N2.5 spends the cap and
+        # halts on `impl.scaffold_suite_invalid`, which is registered, halting
+        # and `upstream_artifact`.
+        #
+        # No `error_message`: since #2756 a recorded reason routes to HALT, so
+        # leaving one here would end the run instead of rerouting it.
+        print("    [GUARD] No tests ran -- rerouting to the scaffolder; "
+              "the scaffold cap decides when to stop (#2767)")
         return {
             "red_phase_output": output,
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
-            "error_message": "Red phase failed: No tests were collected/run",
-            "next_node": "END",
+            "error_message": "",
+            "next_node": "N2_scaffold_tests",
         }
 
     # Success: all tests failed or errored as expected
@@ -2666,13 +2676,17 @@ def _verify_red_non_pytest(
 
     total_red = failed + errors
     if total_red == 0:
-        print("    [GUARD] WARNING: No tests ran!")
+        # #2767: same reroute as the pytest path above, and bounded by the
+        # same cap. Leaving the non-pytest path halting would make the fix a
+        # property of the framework the run happens to use.
+        print("    [GUARD] No tests ran -- rerouting to the scaffolder; "
+              "the scaffold cap decides when to stop (#2767)")
         return {
             "red_phase_output": output,
             "file_counter": file_num,
             "test_run_result": dict(result),
-            "error_message": "Red phase failed: No tests were collected/run",
-            "next_node": "END",
+            "error_message": "",
+            "next_node": "N2_scaffold_tests",
         }
 
     print(f"    Red phase PASSED: {total_red} tests failed as expected ({framework.value})")

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 309,
-    "sites_examined": 8792,
+    "sites_examined": 8798,
     "findings_total": 534
   },
   "undeclared": [

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage rises above this, and when model_output_halt_rows differs from it in EITHER direction (#2759). A row that stops halting, or that leaves the model-output category, lowers the number in the same PR -- so the denominator is never stale. Raise either only with an operator ruling named in the row's created_by or justified_by, in the same PR.",
   "measured_against": {
     "files_scanned": 184,
-    "halt_sites": 147,
+    "halt_sites": 145,
     "gates": 94
   },
   "halt_rows_per_stage": {

--- a/tests/unit/test_rescaffold_is_bounded.py
+++ b/tests/unit/test_rescaffold_is_bounded.py
@@ -1,0 +1,281 @@
+"""A suite that collects nothing is rewritten, and the loop is bounded (#2767).
+
+Two halves of one operator ruling, 2026-09-04.
+
+**The budget counts every regeneration.** It used to count only the passes
+that failed validation: `new_attempts = scaffold_attempts + 1 if not is_valid
+else scaffold_attempts`, and the exhaustion check sat inside `if not
+is_valid:`. So a regenerated suite that passed validation incremented nothing
+and consulted nothing, and the `N3 -> N2` reroute shipped under #292 had no
+bound of its own. The only thing holding it up was LangGraph's default of 25
+super-steps, which raises an error with no gate key, no registry row, and no
+halt bundle -- the artifact a stopped run leaves behind.
+
+**So the red phase can now send a suite back.** "No tests were collected"
+used to end the run. It routes to the scaffolder instead, and the cap that
+already existed stops it: `impl.scaffold_suite_invalid`, registered, halting,
+`upstream_artifact`.
+
+The acceptance is the one the ruling names: a roll whose scaffolder keeps
+producing a valid suite that collects nothing halts **at the cap**, not at the
+recursion limit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    MAX_SCAFFOLD_ATTEMPTS,
+    validate_tests_mechanical_node,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import verify_red_phase
+
+#: A suite that passes mechanical validation: real imports, real test
+#: functions, real assertions. Nothing here is a stub.
+VALID_SUITE = '''\
+import pytest
+
+from widget.core import combine
+
+
+def test_combine_adds():
+    assert combine(1, 2) == 3
+
+
+def test_combine_rejects_none():
+    with pytest.raises(TypeError):
+        combine(None, 1)
+'''
+
+
+def _validation_state(attempts: int, previous_hash: str = "") -> dict:
+    return {
+        "generated_tests": VALID_SUITE,
+        "parsed_scenarios": {"scenarios": [
+            {"id": "S1", "description": "combine adds"},
+            {"id": "S2", "description": "combine rejects None"},
+        ]},
+        "scaffold_attempts": attempts,
+        "previous_scaffold_hash": previous_hash,
+        "issue_number": 4242,
+    }
+
+
+def _pytest_result(returncode: int, passed=0, failed=0, errors=0):
+    return {
+        "returncode": returncode,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {
+            "passed": passed, "failed": failed,
+            "errors": errors, "coverage": 0,
+        },
+    }
+
+
+def _red_state(**overrides) -> dict:
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 4242,
+        "iteration_count": 0,
+        "max_iterations": 10,
+        "coverage_target": 90,
+        "implementation_files": [],
+        "skip_e2e": True,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestTheBudgetCountsEveryRegeneration:
+    def test_a_valid_pass_now_spends_budget(self):
+        """The half-sentence the whole ruling turns on."""
+        result = validate_tests_mechanical_node(_validation_state(0))
+        assert result["validation_result"]["is_valid"], result
+        assert result["scaffold_attempts"] == 1, (
+            "a pass that validated spent nothing, so nothing bounds a reroute"
+        )
+        assert result["scaffold_route"] == "continue"
+
+    def test_the_cap_stops_a_valid_suite_once_the_allowance_is_exceeded(self):
+        """Each pass a DIFFERENT valid suite, so the byte-identical guard is
+        not what stops it -- the cap has to be.
+
+        It stops on the pass after the allowance, not on the pass that
+        reaches it: a suite that validates exactly at the cap is the one a
+        run's last permitted retry produced, and killing that would make the
+        budget punish the retry it exists to allow.
+        """
+        attempts = 0
+        previous = ""
+        routes = []
+        for pass_number in range(1, MAX_SCAFFOLD_ATTEMPTS + 2):
+            state = _validation_state(attempts, previous)
+            # A different suite each time: same shape, one more test.
+            state["generated_tests"] = VALID_SUITE + (
+                f"\n\ndef test_extra_{pass_number}():\n"
+                f"    assert combine({pass_number}, 0) == {pass_number}\n"
+            )
+            result = validate_tests_mechanical_node(state)
+            assert result["validation_result"]["is_valid"], result
+            attempts = result["scaffold_attempts"]
+            previous = result.get("previous_scaffold_hash", "")
+            routes.append(result["scaffold_route"])
+
+        assert attempts == MAX_SCAFFOLD_ATTEMPTS + 1
+        assert routes[-1] == "escalate", (
+            f"the cap did not stop it: {routes}"
+        )
+        assert routes[:-1] == ["continue"] * MAX_SCAFFOLD_ATTEMPTS, routes
+
+    def test_the_halt_does_not_claim_a_validated_suite_failed_validation(self):
+        """The message a human reads to diagnose the halt has to be true.
+
+        The exhaustion message said "the generated test suite cannot be
+        validated", which is false of a suite that passed every check this
+        node makes. What ran out is the budget.
+        """
+        attempts = 0
+        previous = ""
+        result: dict = {}
+        for pass_number in range(1, MAX_SCAFFOLD_ATTEMPTS + 2):
+            state = _validation_state(attempts, previous)
+            state["generated_tests"] = VALID_SUITE + (
+                f"\n\ndef test_extra_{pass_number}():\n"
+                f"    assert combine({pass_number}, 0) == {pass_number}\n"
+            )
+            result = validate_tests_mechanical_node(state)
+            attempts = result["scaffold_attempts"]
+            previous = result.get("previous_scaffold_hash", "")
+
+        message = result.get("error_message", "")
+        assert message, "the cap fired but named no reason"
+        assert "the scaffold budget is spent" in message, message
+        assert "cannot be validated" not in message, (
+            "the halt says a suite that validated could not be validated"
+        )
+
+    def test_an_invalid_pass_still_escalates_at_the_same_cap(self):
+        """The invalid path's budget is unchanged: this ruling widened what
+        counts, it did not move the line."""
+        attempts = 0
+        result: dict = {}
+        for _ in range(MAX_SCAFFOLD_ATTEMPTS):
+            state = _validation_state(attempts)
+            state["generated_tests"] = "def test_nothing():\n    pass\n"
+            result = validate_tests_mechanical_node(state)
+            attempts = result["scaffold_attempts"]
+        assert result["scaffold_route"] == "escalate"
+        assert "cannot be validated" in result.get("error_message", "")
+
+
+class TestTheRedPhaseSendsAnEmptySuiteBack:
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.Path.exists",
+           return_value=True)
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    def test_no_tests_collected_reroutes_instead_of_halting(
+        self, _log, mock_pytest, _exists
+    ):
+        """Exit 1 with nothing collected: the run used to end here.
+
+        Distinct from the exit-5 route already covered by #292 -- this is the
+        path where pytest returns a normal code and simply ran nothing.
+        """
+        mock_pytest.return_value = _pytest_result(1, passed=0, failed=0, errors=0)
+        result = verify_red_phase(_red_state())
+
+        assert result["next_node"] == "N2_scaffold_tests"
+        assert result["error_message"] == "", (
+            "a reroute that records a reason routes to HALT instead (#2756)"
+        )
+
+
+class TestTheLoopEndsAtTheCapNotTheRecursionLimit:
+    """The claim the ruling actually cares about, on the real compiled graph."""
+
+    @pytest.fixture
+    def rolled(self, monkeypatch, tmp_path):
+        import assemblyzero.workflows.testing.graph as g
+
+        entries = {"scaffold": 0}
+
+        def fake_load(state):
+            return {"lld_content": "# LLD\n", "spec_path": "spec.md",
+                    "error_message": ""}
+
+        def fake_review(state):
+            return {"test_plan_status": "APPROVED", "error_message": ""}
+
+        def fake_scaffold(state):
+            entries["scaffold"] += 1
+            # A different valid suite every time, so the byte-identical guard
+            # is not what ends this -- the cap must be.
+            return {
+                "generated_tests": VALID_SUITE + (
+                    f"\n\ndef test_extra_{entries['scaffold']}():\n"
+                    f"    assert combine({entries['scaffold']}, 0) "
+                    f"== {entries['scaffold']}\n"
+                ),
+                "parsed_scenarios": {"scenarios": [
+                    {"id": "S1", "description": "combine adds"},
+                    {"id": "S2", "description": "combine rejects None"},
+                ]},
+                "test_files": [str(tmp_path / "test_example.py")],
+                "error_message": "",
+            }
+
+        monkeypatch.setattr(g, "load_lld", fake_load)
+        monkeypatch.setattr(g, "review_test_plan", fake_review)
+        monkeypatch.setattr(g, "scaffold_tests", fake_scaffold)
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.run_pytest",
+            lambda *a, **k: _pytest_result(1, passed=0, failed=0, errors=0),
+        )
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution",
+            lambda **k: None,
+        )
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.Path.exists",
+            lambda self: True,
+        )
+
+        app = g.build_testing_workflow().compile()
+        final = app.invoke({
+            "issue_number": 4242,
+            "repo_root": str(tmp_path),
+            "worktree_path": str(tmp_path),
+            "audit_dir": "",
+            "max_iterations": 5,
+        })
+        return final, entries
+
+    def test_it_terminates_rather_than_running_out_of_super_steps(self, rolled):
+        """If this raised, the loop was never bounded and the fixture would
+        have failed with GraphRecursionError before reaching any assertion."""
+        final, _ = rolled
+        assert final is not None
+
+    def test_it_halts_on_the_cap_that_already_existed(self, rolled):
+        final, _ = rolled
+        message = final.get("error_message", "")
+        assert "scaffold budget is spent" in message, message
+
+    def test_the_scaffolder_ran_exactly_the_budget(self, rolled):
+        """Bounded at the documented number, not merely finite.
+
+        The allowance is `MAX_SCAFFOLD_ATTEMPTS` regenerations; the pass that
+        exceeds it is the one refused, so the scaffolder runs one more time
+        than the cap and the last of those produces the suite nobody gets to
+        use. That off-by-one is the deliberate asymmetry in
+        `exhausted_reason`, not slack in the bound.
+        """
+        _, entries = rolled
+        assert entries["scaffold"] == MAX_SCAFFOLD_ATTEMPTS + 1, entries

--- a/tests/unit/test_spec_stage_pair.py
+++ b/tests/unit/test_spec_stage_pair.py
@@ -121,7 +121,56 @@ class TestEscalationHalts:
         assert DETERMINISTIC_FAILURE in result["error_message"]
         assert "byte for byte" in result["error_message"]
 
-    def test_a_valid_suite_is_never_halted(self):
+    def test_a_valid_suite_is_never_halted_for_being_invalid(self):
+        """Renamed and narrowed by #2767 (operator ruling 2026-09-04).
+
+        This asserted that a valid suite is never halted, full stop, with
+        `scaffold_attempts` already at the cap. That invariant is what the
+        ruling overturned: the scaffold budget now counts every regeneration,
+        because a budget that counts only failures is not a budget, and a
+        suite arriving after the allowance is spent stops the loop.
+
+        What is still true, and is what this now pins: a valid suite is never
+        halted for failing validation, and one that arrives with budget
+        remaining proceeds. The regression that would matter -- a run whose
+        third scaffold finally validates being killed at the moment it
+        succeeded -- is pinned by the test below.
+        """
+        real = "import pytest\n\ndef test_a():\n    assert 1 == 1\n"
+        state = {
+            "generated_tests": real,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 0,
+        }
+        result = validate_tests_mechanical_node(state)
+        assert "error_message" not in result
+        assert result["scaffold_route"] == "continue"
+
+    def test_the_scaffold_that_finally_validates_is_allowed_through(self):
+        """The no-regression case for #2767, and the reason the valid path's
+        threshold is `>` rather than `>=`.
+
+        Two scaffolds failed validation; the third passed. That run produced
+        exactly what was asked for, and the retry budget exists to allow the
+        retry that got there.
+        """
+        real = "import pytest\n\ndef test_a():\n    assert 1 == 1\n"
+        state = {
+            "generated_tests": real,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS - 1,
+        }
+        result = validate_tests_mechanical_node(state)
+
+        assert result["scaffold_attempts"] == MAX_SCAFFOLD_ATTEMPTS
+        assert "error_message" not in result, (
+            "the third scaffold validated and was halted anyway"
+        )
+        assert result["scaffold_route"] == "continue"
+
+    def test_a_valid_suite_past_the_cap_stops_the_loop(self):
+        """#2767's other half: once the allowance is spent, a suite that
+        validates and still cannot be used ends the run on the budget."""
         real = "import pytest\n\ndef test_a():\n    assert 1 == 1\n"
         state = {
             "generated_tests": real,
@@ -129,7 +178,12 @@ class TestEscalationHalts:
             "scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS,
         }
         result = validate_tests_mechanical_node(state)
-        assert "error_message" not in result
+
+        assert result["scaffold_route"] == "escalate"
+        assert "scaffold budget is spent" in result["error_message"]
+        assert "cannot be validated" not in result["error_message"], (
+            "the halt says a suite that validated could not be validated"
+        )
 
     def test_one_condition_serves_both_callers(self):
         """The route and the halt message must never disagree.


### PR DESCRIPTION
Ranked item 1, on the operator's ruling of 2026-09-04.

## The budget counted only failures

```python
new_attempts = scaffold_attempts + 1 if not is_valid else scaffold_attempts
...
if not is_valid:
    reason = _halt_if_exhausted(...)          # <- the cap, unreachable from the valid path
```

A regenerated suite that **passed** validation incremented nothing and consulted nothing. That is why the `N3 → N2` reroute shipped under #292 had no bound of its own: nothing on the valid path could ever reach `MAX_SCAFFOLD_ATTEMPTS`.

Both are unconditional now, on the pytest path and in `_validate_non_pytest`, so the fix is not a property of the framework a run happens to use.

## So the red phase can send an empty suite back

"No tests were collected/run" ended the run, once per framework path. Both now route to `N2_scaffold_tests`, and — this part matters since #2756 — they record **no** `error_message`, because a return that records a reason routes to `HALT` and would end the run instead of rerouting it.

The loop is stopped by the cap and the halt that already existed: **`impl.scaffold_suite_invalid`** — registered, halting, `upstream_artifact`. No new row, no halt count rises, exactly as the ruling required.

## The threshold is asymmetric, and the full suite is why

The first implementation made both paths unconditional — increment always, check always, `attempts >= MAX_SCAFFOLD_ATTEMPTS` for both. `test_spec_stage_pair.py::TestEscalationHalts::test_a_valid_suite_is_never_halted` went red, and it was right to.

Under that version, a run whose first two scaffolds failed validation and whose **third finally passed** was halted at the moment it succeeded: `fail → 1, fail → 2, valid → 3`, and `3 >= 3` ends the run holding exactly the suite it was asked to produce. That is the retry budget punishing the retry it exists to allow, and no reading of the ruling wants it.

So the two paths differ, deliberately:

| path | stops when | why |
|---|---|---|
| invalid | `attempts >= MAX` | three scaffolds, none usable — a fourth will not be different. Unchanged from what shipped. |
| valid | `attempts > MAX` | the loop has already been round the allowed number of times and is asking for one more |

The consequence for the acceptance test is an off-by-one worth naming rather than hiding: the scaffolder runs `MAX_SCAFFOLD_ATTEMPTS + 1` times, because the pass that *exceeds* the allowance is the one refused. Three regenerations are permitted; the fourth is not.

The old test is renamed to what it still pins — a valid suite is never halted *for being invalid* — and two new ones pin both sides of the line: the third scaffold that finally validates goes through, and a valid suite past the cap stops the loop.

## One message was lying on the path this PR opens

The exhaustion halt said *"the generated test suite cannot be validated and …"*. On the valid path that is false: the suite passed every check the node makes, and what ran out is the budget. It now says so. A halt message is the artifact a human reads to work out why a run stopped, and this PR is what would have started producing the false one.

## Proven against the behaviour, not asserted

`tests/unit/test_rescaffold_is_bounded.py`, 8 tests. The one the ruling asked for rolls the **real compiled testing graph** with a scaffolder that returns a *different* valid suite each pass — so the byte-identical guard cannot be what stops it — and a red phase whose pytest reports nothing collected. It asserts the roll ends on the cap's message with the scaffolder having run exactly `MAX_SCAFFOLD_ATTEMPTS + 1` times — bounded at the documented number, not merely finite.

**The mutation that shows the test is real:** revert the one-line increment and that same roll dies with

```
langgraph.errors.GraphRecursionError: Recursion limit of 10007 reached without hitting a stop condition
```

Two other tests pin the halves that could regress quietly: an invalid suite still escalates at the same cap (this ruling widened what counts, it did not move the line), and the real `verify_red_phase` returns the reroute shape with an empty `error_message`.

## Ratchet

| | before | after |
|---|---|---|
| halt sites | 147 | **145** |
| gates | 94 | 94 |
| impl halt rows | 34 | 34 |
| model-output halt rows | 4 | 4 |

Two returns stopped being halt sites; no row changed action. Both baselines regenerated in this PR: the fail-open audit's `sites_examined` moves 8792 → 8798 for the branches these edits add, with `findings_total` unchanged at 534 — no new fail-open site.

**The count does not reach 3 in this PR.** `impl.red_phase_failed` keeps one site: the non-pytest unexpected-pass case, which #2337 fixed for pytest and never ported. The ruling named it a separate concern, and it is filed as **#2796** with both candidate remedies and what decides between them — porting the red-entry-marker check, or moving the site beside its pytest twin and calling it deterministic, which is the conservative reading since retrying an unchanged worktree reproduces the result either way. The row's `notes` now say this is why the count is 4 rather than 3.

## A correction to #2790, made while proving this

#2790 states LangGraph's default recursion limit as **25** and argues the implementation stage has zero margin at its iteration cap. That number came from memory, not from the installed package. Measured:

```
langgraph/_internal/_config.py:32
DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10007"))
```

The zero-margin claim is void, and the mutation above confirms 10007 empirically. What survives is that the implementation stage passes no `recursion_limit` where the spec stage derives one, and that an unbounded loop there burns 10007 super-steps — in this stage a super-step can be an LLM call — before dying with no gate key and no halt bundle. Worse in cost than the original framing, harmless to a converging run. Posted on #2790; its remaining half is re-justified on that basis.

Closes #2767
