### PR TITLE
fix: split the deterministic-failure row, one owner per condition (Closes #2761)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -655,16 +655,56 @@ GATE_REGISTRY: tuple[Gate, ...] = (
         _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 3),
         notes="the tests import modules the codebase does not have",
     ),
+    # #2761 (operator ruling 2026-09-04): one row named two different things,
+    # and the report could not say which of its kills was which. Split, and
+    # the code's own message decides each half's owner.
+    #
+    # This split is the authorised rise: `halt_rows_per_stage['impl']` goes
+    # 34 -> 35. No new place can stop a run -- halt SITES are unchanged,
+    # both returns already existed -- and the model-output count is unchanged
+    # too, because one half leaves the category as the other keeps it.
+    Gate(
+        "impl.red.preexisting_implementation", "impl", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT,
+        # Found in the site's own static head, not by the `decided_in`
+        # file-wide fallback: the old row's emits was the bare token, which
+        # lives in validate_tests_mechanical.py and so matched a file rather
+        # than a return. That is the weakness #2776 is about.
+        "tests passed unexpectedly, and neither a red-entry marker",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 4),
+        decided_in=f"{_TS}/nodes/verify_phases.py::verify_red_phase",
+        created_by="#2337", justified_by="#2761",
+        notes=(
+            "infrastructure by the #2761 ruling, and the message says why: "
+            "'neither a red-entry marker nor this run's own prior writes "
+            "explain them -- the implementation existed before this stage "
+            "entered'. That is the state of the worktree the stage was "
+            "handed, not something the drafter wrote. Deterministic on an "
+            "unchanged tree, which is why it carries the token and is not "
+            "retried. Both recorded kills are here: run-issue331 on the "
+            "pre-#2337 message, run-issue379 on this one"
+        ),
+    ),
     Gate(
         "impl.deterministic_failure", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
-        "DETERMINISTIC FAILURE",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 4)
-        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 4),
-        decided_in=f"{_TS}/nodes/validate_tests_mechanical.py",
+        # This one still needs the `decided_in` fallback, and it is worth
+        # saying why: the return is `f"{DETERMINISTIC_FAILURE}: {message}"`,
+        # so its static head is literally "{}: {}" and carries no text at
+        # all. `decided_in` now names the function that composes the message
+        # rather than the module that defines the token, which is the honest
+        # pointer and the narrowest the check can currently be given.
+        "Test(s) failing for a reason no implementation can fix",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 4),
+        decided_in=f"{_TS}/nodes/verify_phases.py::verify_green_phase",
+        justified_by="#2761",
         notes=(
-            "tests passed before the code existed, or fail for a platform reason no "
-            "implementation can fix; the scaffolder's suite-invalid halt shares the "
-            "prefix and is impl.scaffold_suite_invalid"
+            "model_output by the #2761 ruling, and the message says that too "
+            "-- 'The TEST is the wrong side here, fix or remove it'. N4c "
+            "generated the test; a platform error is how the defect shows, "
+            "not whose it is. Zero kills in the 180-run window. Keeps the "
+            "key because the answer-key audit's stub count reports under it, "
+            "and a hollow test and an unsatisfiable one are one family: a "
+            "test no implementation can make pass"
         ),
     ),
     Gate(

--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -322,13 +322,30 @@ CAUSE_TABLE: tuple[Cause, ...] = (
         "and the scaffolder",
         "the generated test suite cannot be",
     ),
+    # #2761 split the last of the three in two, because it also named two
+    # things: the worktree already held the implementation (the pipeline's
+    # fault) and a generated test cannot pass anywhere (the drafter's). Both
+    # rows are specific -- there is deliberately no generic
+    # `DETERMINISTIC FAILURE` catch-all left, so a fourth emitter of the token
+    # lands in `unclassified` and gets printed verbatim rather than absorbed
+    # by a neighbour, which is how the first three came to share one row.
     Cause(
-        "impl.deterministic_failure", r"DETERMINISTIC FAILURE",
-        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "impl.red.preexisting_implementation",
+        r"DETERMINISTIC FAILURE: Red phase failed",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py",
+        "infrastructure",
         "DETERMINISTIC FAILURE: Red phase failed: 3 tests passed "
         "unexpectedly, and neither a red-entry marker nor this run's own "
         "prior writes explain them",
         "tests passed unexpectedly, and neither a red-entry marker",
+    ),
+    Cause(
+        "impl.deterministic_failure",
+        r"DETERMINISTIC FAILURE: Test\(s\) failing for a reason",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "DETERMINISTIC FAILURE: Test(s) failing for a reason no "
+        "implementation can fix: test_dynamic_256_matches_baseline",
+        "Test(s) failing for a reason no implementation can fix",
     ),
     Cause(
         "impl.red_phase_failed", r"Red phase failed",

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -3,10 +3,10 @@
   "measured_against": {
     "files_scanned": 184,
     "halt_sites": 145,
-    "gates": 94
+    "gates": 95
   },
   "halt_rows_per_stage": {
-    "impl": 34,
+    "impl": 35,
     "lld": 15,
     "orchestrator": 16,
     "pr": 1,

--- a/tests/unit/test_factory_report.py
+++ b/tests/unit/test_factory_report.py
@@ -647,29 +647,71 @@ class TestCauseTable:
         The tell was inside the table: that row's `example` was the
         scaffolder's message, so the row was documented -- and
         `test_every_row_matches_its_own_example` pinned -- against a gate it
-        is not. Both of these are real banner heads from the run logs.
+        is not.
+
+        #2761's ruling then split the last of the three, because it also
+        named two things. Four now, each with its own key, and the first
+        three are real banner heads from the run logs. The green-phase one
+        has never fired, so its text comes from the code that composes it.
         """
         scaffolder = (
             "DETERMINISTIC FAILURE: the generated test suite cannot be "
             "validated and the scaffolder reproduced its previous output"
         )
-        red_phase = (
+        red_preexisting = (
             "DETERMINISTIC FAILURE: Red phase failed: 3 tests passed "
             "unexpectedly, and neither a red-entry marker nor this run's own "
             "prior writes explain them"
         )
+        red_old_message = (
+            "DETERMINISTIC FAILURE: Red phase failed: 8 tests passed "
+            "unexpectedly. Tests should fail before implementation exists."
+        )
+        green_unsatisfiable = (
+            "DETERMINISTIC FAILURE: Test(s) failing for a reason no "
+            "implementation can fix: test_dynamic_256_matches_baseline"
+        )
         assert classify_cause(scaffolder) == "impl.scaffold_suite_invalid"
-        assert classify_cause(red_phase) == "impl.deterministic_failure"
+        assert classify_cause(red_preexisting) == "impl.red.preexisting_implementation"
+        assert classify_cause(green_unsatisfiable) == "impl.deterministic_failure"
+
+        # run-issue331 died on the pre-#2337 wording. It has to keep landing
+        # on the red row, or a historical kill silently becomes unclassified.
+        assert classify_cause(red_old_message) == "impl.red.preexisting_implementation"
+
+    def test_no_generic_deterministic_row_absorbs_a_fourth_emitter(self):
+        """#2761: there is deliberately no catch-all left.
+
+        A fifth thing that prepends the token should land in `unclassified`
+        and be printed verbatim, which is how the table grows deliberately.
+        Absorbing it into the nearest row is what produced the original
+        defect.
+        """
+        invented = "DETERMINISTIC FAILURE: something nobody has written yet"
+        assert classify_cause(invented) == CAUSE_UNCLASSIFIED
 
     def test_a_specific_cause_row_precedes_the_generic_one_it_shares_a_prefix_with(
         self,
     ):
         """Order is load-bearing: `classify_cause` takes the FIRST match, so a
-        specific row placed after its generic sibling can never fire."""
+        specific row placed after its generic sibling can never fire.
+
+        After #2761 all four token-sharing rows are specific and none is a
+        prefix of another, so ordering among them no longer decides anything.
+        What still must hold is that every one of them precedes
+        `impl.red_phase_failed`, whose bare `Red phase failed` pattern would
+        otherwise claim the red-phase deterministic messages.
+        """
         keys = [cause.key for cause in CAUSE_TABLE]
-        assert keys.index("impl.scaffold_suite_invalid") < keys.index(
-            "impl.deterministic_failure"
-        )
+        for specific in (
+            "impl.scaffold_suite_invalid",
+            "impl.red.preexisting_implementation",
+            "impl.deterministic_failure",
+        ):
+            assert keys.index(specific) < keys.index("impl.red_phase_failed"), (
+                f"{specific} is ordered after impl.red_phase_failed, whose "
+                f"broader pattern will match first"
+            )
 
     def test_every_row_names_code_that_says_what_the_row_claims(self):
         for cause in CAUSE_TABLE:


### PR DESCRIPTION
Ranked item 2, on the operator's ruling of 2026-09-04: split the row, and the code's reading is the right one.

## Two conditions, one name

| new key | judges | fires when | kills |
|---|---|---|---|
| `impl.red.preexisting_implementation` | `infrastructure` | tests pass at red and *"neither a red-entry marker nor this run's own prior writes explain them — the implementation existed before this stage entered"* | **2** |
| `impl.deterministic_failure` | `model_output` | *"Test(s) failing for a reason no implementation can fix … The TEST is the wrong side here, fix or remove it"* | **0** |

The first is the state of the worktree the stage was handed. The second is a test N4c generated; a platform error is how that defect shows, not whose it is.

The green half keeps the old key because the answer-key audit's stub-count check reports under it, and a hollow test and an unsatisfiable one are one family — a test no implementation can make pass. That also keeps `impl.deterministic_failure` `model_output`, which is what `test_every_runnable_gate_is_registered_and_judges_a_draft` requires of a gate the audit runs.

## The ratchet, and the authorised rise

| | before | after |
|---|---|---|
| halt sites | 145 | **145** |
| gates | 94 | **95** |
| impl halt rows | 34 | **35** |
| model-output halt rows | 4 | **4** |

**No new place can stop a run.** Both returns already existed and neither changed; what rose is the number of *names* for places that already could. `justified_by="#2761"` on both rows, per the ratchet's rule for a rise.

Model-output is unchanged because one half leaves the category exactly as the other keeps it — which is what the ruling predicted.

## Counted over all 180 run logs

| by what the gate judges | before | after |
|---|---|---|
| `model_output` | 29 | **27** |
| `infrastructure` | 8 | **10** |
| `budget` | 45 | 45 |
| `issue_body` | 34 | 34 |
| `upstream_artifact` | 4 | 4 |
| `unrecorded` | 15 | 15 |

135 failed runs classified both times, **nothing unclassified**. The two red-phase kills moved to the half that owns them. Answer-key audit unchanged at **50 verdicts / 1 refusal**.

## No catch-all is left, deliberately

Both cause rows are specific. There is no generic `DETERMINISTIC FAILURE` row any more, so a fourth emitter of the token lands in `unclassified` and is printed verbatim rather than absorbed by a neighbour — which is exactly how the first three came to share one row. A test pins that.

Another pins something easy to lose: `run-issue331` died on the **pre-#2337 wording** (*"Tests should fail before implementation exists."*), which must keep landing on the red row or a historical kill silently becomes unclassified.

## What this turned up about #2776

The pairing check `test_emits_is_a_true_statement_about_the_code` went red on the first attempt, and the reason is item 9's subject.

A row's `emits` must appear in one of its sites' static heads — **or anywhere in the file named by `decided_in`**. The old row's `emits` was the bare token `DETERMINISTIC FAILURE`, which is defined in `validate_tests_mechanical.py`:

```python
DETERMINISTIC_FAILURE = "DETERMINISTIC FAILURE"
```

So the row satisfied the check by matching a **file**, not a return. That is the loophole #2776 is about, found in the wild rather than by reading.

The red half now uses text from its own site head. The green half still needs the fallback, and the row says so plainly: its return is `f"{DETERMINISTIC_FAILURE}: {message}"`, whose static head is literally `"{}: {}"` and carries no text at all — no `emits` string could ever match it. `decided_in` now names the function that composes the message rather than the module that defines the token, which is the narrowest honest pointer available without restructuring the return.

That is one measured example for item 9's count.

Closes #2761
