### PR TITLE
fix: a test that calls the code and does not raise has asserted something (Closes #2754)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -13,6 +13,7 @@ import ast
 import hashlib
 import logging
 import re
+import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -230,6 +231,117 @@ def _called_names(func: ast.AST) -> list[str]:
     return names
 
 
+#: Test-framework roots whose names are never "the code under test" (#2754).
+#: A closed, enumerable set, as §28a asks of any list a decision reads: every
+#: member is written here, and the stdlib half is the interpreter's own
+#: `sys.stdlib_module_names` rather than a list anyone has to maintain.
+FRAMEWORK_MODULE_ROOTS: frozenset[str] = frozenset({
+    "pytest", "_pytest", "unittest", "mock", "hypothesis", "freezegun",
+})
+
+
+def _code_under_test_names(tree: ast.AST) -> set[str]:
+    """Names this test file imports from the module it TARGETS (#2754).
+
+    Answered the way a resolver would answer it, not by judgement. Three
+    conditions, and the third is the one that took a red suite to find.
+
+    Not the standard library, and not a test framework -- `sys.stdlib_module_names`
+    and `FRAMEWORK_MODULE_ROOTS`.
+
+    And imported by a DOTTED package path. That is what separates the code
+    under test from a test helper, and the separation is structural rather
+    than stylistic: the code under test lives in the package being built and
+    is imported as `from boostgauge.telltale import Telltale`, while a helper
+    sits beside the test file and is imported bare -- `from helpers import
+    assert_accepted` -- or relatively. A first cut of this treated every
+    first-party import as a target, and it accepted a test whose only call
+    was to a `pass`-bodied helper, because the helper's name looked like
+    production code.
+
+    Erring bare-is-a-helper errs toward REFUSING, which is the safe direction
+    for a gate whose job is to keep hollow suites out. A genuinely flat
+    single-module package would be read as a helper and its test refused;
+    nothing in the corpus imports that way, and a false refusal costs a round
+    while a false acceptance ships a suite that tests nothing.
+
+    `import boostgauge.telltale` binds the ROOT, so `boostgauge` is what a
+    call site writes and what goes in the set.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # A relative import is a sibling: a helper by position.
+            if node.level:
+                continue
+            module = node.module or ""
+            if "." not in module:
+                continue
+            root = module.split(".")[0]
+            if root in sys.stdlib_module_names or root in FRAMEWORK_MODULE_ROOTS:
+                continue
+            names.update(a.asname or a.name for a in node.names)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if "." not in alias.name:
+                    continue
+                root = alias.name.split(".")[0]
+                if root in sys.stdlib_module_names or root in FRAMEWORK_MODULE_ROOTS:
+                    continue
+                names.add(alias.asname or root)
+    return names
+
+
+def _exercises_code_under_test(
+    func: ast.AST,
+    targets: set[str],
+    functions: dict[str, ast.AST],
+    depth: int = 0,
+) -> bool:
+    """Whether ``func`` calls into the code under test, directly or one down.
+
+    Operator ruling, 2026-09-04 (#2754): a test body that calls into the code
+    under test and carries no `assert` is a test whose assertion is "does not
+    raise" -- accepted. A body with no such call and no assertion is a stub --
+    refused.
+
+    Following one level through a same-module helper matches #2737's reading
+    and is what the shipped case needs: boostgauge's
+    `test_V4_equal_timestamp_is_accepted` calls `_fed(...)`, and it is `_fed`
+    that constructs the `Telltale` the test is about.
+
+    An attribute call counts when the ROOT of its value chain is a target, so
+    `sk.render(...)` after `from boostgauge.skins import stingray as sk` is a
+    call into the code under test. A method on a local (`t.update(...)`) is
+    NOT resolved -- that needs type inference -- which is exactly why
+    following the helper is load-bearing rather than a convenience.
+    """
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if isinstance(target, ast.Name):
+            if target.id in targets:
+                return True
+        elif isinstance(target, ast.Attribute):
+            root = target.value
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name) and root.id in targets:
+                return True
+
+    if depth >= ASSERTION_FOLLOW_DEPTH:
+        return False
+
+    for name in _called_names(func):
+        helper = functions.get(name)
+        if helper is None or helper is func:
+            continue
+        if _exercises_code_under_test(helper, targets, functions, depth + 1):
+            return True
+    return False
+
+
 def _carries_an_assertion(
     func: ast.AST,
     functions: dict[str, ast.AST],
@@ -317,11 +429,25 @@ def validate_test_structure(
         errors.append("No import statements found - tests need imports")
 
     functions = _module_functions(tree)
+    #: #2754: what "the code under test" means for this file, computed once.
+    #: A name defined in this file is a helper whatever it was imported as,
+    #: so it is never a target -- a local definition shadows the import, and
+    #: a `pass`-bodied local must not be read as production code.
+    targets = _code_under_test_names(tree) - set(functions)
 
     # Check each test function
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith('test_'):
             if _carries_an_assertion(node, functions, imported_sources):
+                continue
+
+            # #2754, operator ruling 2026-09-04: no assertion, but it calls
+            # into the code under test -- the assertion is "does not raise",
+            # and boostgauge's shipped `test_V4_equal_timestamp_is_accepted`
+            # says so in a trailing comment. A stub is the other case: no
+            # assertion AND no call into the code under test, which is what
+            # the checks below still refuse.
+            if _exercises_code_under_test(node, targets, functions):
                 continue
 
             # Check if function only has pass

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 309,
-    "sites_examined": 8798,
+    "sites_examined": 8820,
     "findings_total": 534
   },
   "undeclared": [

--- a/tests/unit/test_assertion_reading.py
+++ b/tests/unit/test_assertion_reading.py
@@ -71,16 +71,20 @@ class TestTheShippedArtifacts:
         failing a test was invisible to it."""
         assert messages(STINGRAY_SHAPE) == []
 
-    def test_the_must_not_raise_test_is_still_refused(self):
-        """Deliberately pinned as still-refused rather than quietly accepted.
-        There is no assertion in the body and none one level down: `_fed`
-        constructs and calls, and `t.update` is an attribute on a local that no
-        parser resolves. The ruling on whether absence-of-exception counts is
-        #2754; until it lands, this test records the honest state rather than a
-        number massaged to look finished."""
-        errors = messages(MUST_NOT_RAISE_SHAPE)
-        assert len(errors) == 1
-        assert "test_V4_equal_timestamp_is_accepted" in errors[0]
+    def test_the_must_not_raise_test_is_now_accepted(self):
+        """#2754 landed, and this is the test that was waiting for it.
+
+        It was pinned as still-refused while the ruling was open --
+        deliberately, so the count recorded the honest state rather than a
+        number massaged to look finished. The operator ruled on 2026-09-04:
+        a body that calls into the code under test and carries no `assert` is
+        a test whose assertion is "does not raise".
+
+        Accepted through the helper, not the body: the body never names
+        `Telltale`, `_fed` constructs one. `t.update` is still an attribute on
+        a local that no parser resolves, and still does not need to be.
+        """
+        assert messages(MUST_NOT_RAISE_SHAPE) == []
 
 
 class TestFollowingTheCallOneLevel:

--- a/tests/unit/test_does_not_raise_is_an_assertion.py
+++ b/tests/unit/test_does_not_raise_is_an_assertion.py
@@ -1,0 +1,232 @@
+"""A test that calls the code and does not raise has asserted something (#2754).
+
+Operator ruling, 2026-09-04. The scaffolder's structural validator refused
+boostgauge's shipped `test_V4_equal_timestamp_is_accepted`:
+
+    def test_V4_equal_timestamp_is_accepted():
+        t = _fed(10.0, [(5.0, 1.0)])
+        t.update(5.0, 3.0)  # must not raise
+
+That test is correct, the operator wrote it, and the comment says what it
+asserts. The gate refusing it was the last refusal in the answer-key audit --
+the audit that runs the pipeline's mechanical gates over code known to be
+right, where every refusal is a false positive by construction.
+
+The ruling draws the line as a parser question, not a judgement:
+
+- calls into the code under test, no `assert`  -> accepted, the assertion is
+  "does not raise";
+- no call into the code under test, no `assert` -> refused, it is a stub.
+
+"Into the code under test" means a call resolving to a name imported from the
+module the test file targets, directly or through a same-module helper one
+level down. That last clause is load-bearing here: the shipped test never
+names `Telltale`; `_fed` does.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    _code_under_test_names,
+    _exercises_code_under_test,
+    validate_test_structure,
+)
+
+#: The shipped case, verbatim from boostgauge `tests/unit/test_telltale.py`.
+SHIPPED = '''\
+from __future__ import annotations
+
+import pytest
+
+from boostgauge.telltale import Telltale
+
+
+def _fed(window, samples, decay_rate=None):
+    t = Telltale(window, decay_rate=decay_rate)
+    for ts, v in samples:
+        t.update(ts, v)
+    return t
+
+
+def test_V4_equal_timestamp_is_accepted():
+    t = _fed(10.0, [(5.0, 1.0)])
+    t.update(5.0, 3.0)  # must not raise
+'''
+
+#: The other side of the line: a body that calls nothing but the framework
+#: and the standard library.
+FIXTURES_AND_STDLIB_ONLY = '''\
+import math
+
+import pytest
+
+from boostgauge.telltale import Telltale
+
+
+def test_only_touches_fixtures_and_stdlib(tmp_path, request):
+    value = math.floor(3.7)
+    request.config.getoption("--quiet")
+    tmp_path.joinpath("x").write_text(str(value))
+'''
+
+STUB_ONLY = '''\
+from boostgauge.telltale import Telltale
+
+
+def test_nothing_here():
+    pass
+
+
+def test_only_a_docstring():
+    """TDD RED: implementation pending."""
+'''
+
+#: run-issue4-163140's approved spec, whose Section 10 shipped thirteen test
+#: functions. The scaffolder emits them verbatim and its validator refused the
+#: suite 3.4 seconds later.
+RUN8_FIXTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "boostgauge4_stub_tests"
+    / "spec-0004-final-spec.md"
+)
+
+
+class TestWhatCountsAsTheCodeUnderTest:
+    def test_first_party_imports_are_targets_and_the_rest_are_not(self):
+        tree = ast.parse(SHIPPED)
+        assert _code_under_test_names(tree) == {"Telltale"}, (
+            "pytest and __future__ are not the code under test"
+        )
+
+    def test_stdlib_and_framework_roots_are_excluded(self):
+        tree = ast.parse(FIXTURES_AND_STDLIB_ONLY)
+        names = _code_under_test_names(tree)
+        assert "Telltale" in names
+        assert "math" not in names
+        assert "pytest" not in names
+
+    def test_a_relative_import_is_a_sibling_helper_not_a_target(self):
+        tree = ast.parse("from . import helpers\n\ndef test_x():\n    helpers.go()\n")
+        assert _code_under_test_names(tree) == set()
+
+    def test_a_bare_module_import_is_a_helper_not_a_target(self):
+        """The distinction that took a red suite to find.
+
+        `from helpers import assert_accepted` is a test helper sitting beside
+        the test file; `from boostgauge.telltale import Telltale` is the code
+        under test in the package being built. Treating every first-party
+        import as a target accepted a test whose only call was to a
+        `pass`-bodied helper.
+        """
+        tree = ast.parse("from helpers import assert_accepted\n")
+        assert _code_under_test_names(tree) == set()
+
+    def test_an_aliased_module_import_binds_its_root(self):
+        tree = ast.parse("import boostgauge.telltale as tt\n")
+        assert _code_under_test_names(tree) == {"tt"}
+
+
+class TestTheRulingOnTheArtifactThatShowedIt:
+    def test_the_shipped_test_is_accepted(self):
+        """The whole reason #2754 exists."""
+        errors = validate_test_structure(SHIPPED, [])
+        assert errors == [], errors
+
+    def test_it_is_accepted_through_the_helper_not_the_body(self):
+        """The body never names `Telltale`. Drop the helper's call into the
+        code under test and the same body must be refused again -- otherwise
+        this test would pass for the wrong reason."""
+        hollowed = SHIPPED.replace(
+            "    t = Telltale(window, decay_rate=decay_rate)\n"
+            "    for ts, v in samples:\n"
+            "        t.update(ts, v)\n"
+            "    return t\n",
+            "    return object()\n",
+        )
+        assert "return object()" in hollowed, "the fixture edit did not apply"
+        errors = validate_test_structure(hollowed, [])
+        assert any("test_V4_equal_timestamp_is_accepted" in e for e in errors), (
+            f"accepted without any route to the code under test: {errors}"
+        )
+
+
+class TestTheOtherSideOfTheLine:
+    def test_a_body_calling_only_fixtures_and_stdlib_is_refused(self):
+        errors = validate_test_structure(FIXTURES_AND_STDLIB_ONLY, [])
+        assert any(
+            "test_only_touches_fixtures_and_stdlib" in e for e in errors
+        ), errors
+
+    def test_pass_and_docstring_bodies_are_still_refused(self):
+        errors = validate_test_structure(STUB_ONLY, [])
+        assert any("test_nothing_here" in e for e in errors), errors
+        assert any("test_only_a_docstring" in e for e in errors), errors
+
+
+class TestRunEightIsStillRefusedThirteenTimes:
+    """The regression this ruling could most easily have caused.
+
+    Widening "has an assertion" is exactly the change that could let the
+    hollow suite through -- the one that cost 605 seconds of approved spec
+    work before the scaffolder's validator caught it, byte-identical on
+    regeneration, deterministic.
+    """
+
+    def test_the_fixture_is_on_disk(self):
+        assert RUN8_FIXTURE.is_file(), RUN8_FIXTURE
+
+    def test_eleven_of_the_thirteen_are_still_refused(self):
+        """Counted, and the count is 11 of 13 rather than 13 of 13.
+
+        The spec shipped thirteen test functions; eleven of them are a
+        comment and `pass`, and the other two carry real assertions. Eleven
+        is therefore the number the validator named before this ruling and
+        the number it must still name after it -- widening "has an assertion"
+        must not let a single one of them through.
+        """
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (  # noqa: E501
+            check_spec_test_functions_have_assertions,
+        )
+
+        spec = RUN8_FIXTURE.read_text(encoding="utf-8")
+        result = check_spec_test_functions_have_assertions(spec, 4, [])
+
+        assert result["passed"] is False, "the hollow suite from run 8 was accepted"
+        assert "11 of 13" in result["details"], result["details"]
+
+    def test_none_of_them_slipped_through_the_does_not_raise_reading(self):
+        """The specific way this ruling could have broken it.
+
+        A stub body is `pass` or a comment, so it calls nothing at all -- and
+        a body that calls nothing cannot call into the code under test. This
+        asserts that directly on the fixture's own suite rather than trusting
+        the aggregate count above.
+        """
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (  # noqa: E501
+            _spec_test_functions,
+        )
+
+        spec = RUN8_FIXTURE.read_text(encoding="utf-8")
+        functions = _spec_test_functions(spec)["functions"]
+        assert len(functions) == 13, len(functions)
+
+        source = "\n\n".join(
+            f["source"] if isinstance(f, dict) else str(f) for f in functions
+        )
+        targets = _code_under_test_names(ast.parse("import boostgauge"))
+        tree = ast.parse(source) if source.strip() else ast.parse("")
+        exercising = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name.startswith("test_")
+            and _exercises_code_under_test(node, targets, {})
+        ]
+        assert exercising == [], (
+            f"a stub body was read as calling into the code under test: "
+            f"{exercising}"
+        )


### PR DESCRIPTION
Ranked item 3, on the operator's ruling of 2026-09-04.

## The artifact

boostgauge's shipped `tests/unit/test_telltale.py`:

```python
def test_V4_equal_timestamp_is_accepted():
    t = _fed(10.0, [(5.0, 1.0)])
    t.update(5.0, 3.0)  # must not raise
```

Correct, operator-written, and the comment says what it asserts. It was the **last refusal in the answer-key audit** — the audit that runs the pipeline's mechanical gates over code known to be right, where every refusal is a false positive by construction.

## The line, as a parser question

| body | verdict |
|---|---|
| calls into the code under test, no `assert` | **accepted** — the assertion is "does not raise" |
| no call into the code under test, no `assert` | **refused** — it is a stub |

"Into the code under test" is a call resolving to a name imported from the module the test file targets, directly or through a same-module helper one level down (#2737's reading). A name is a target when the import that bound it names neither the standard library nor a test framework — `sys.stdlib_module_names` for the first, and a written-out `FRAMEWORK_MODULE_ROOTS` for the second, which is a closed enumerable set as §28a asks of any list a decision reads.

**The one-level clause is load-bearing, not a convenience.** The shipped test never names `Telltale`. `_fed` does:

```python
def _fed(window, samples, decay_rate=None):
    t = Telltale(window, decay_rate=decay_rate)
```

A test asserts that: hollow out `_fed` so it returns `object()` and the same body must be refused again, or the acceptance would be passing for the wrong reason.

`t.update(...)` is deliberately **not** resolved — that needs type inference, and the analysis stops where a parser stops.

## A test helper is not the code under test, and the suite is how I learned it

The first cut treated **every** first-party import as a target. Three tests went red, and they were right to:

```python
from helpers import check

def check(value):        # a pass-bodied local, shadowing the import
    pass

def test_it():
    check(compute())
```

Accepted, because `check` came from a non-stdlib import and the body called it. That is a hollow test passing the gate — precisely what this checker exists to stop.

The separation is structural, not stylistic. The code under test lives in the package being built and is imported by a **dotted path** (`from boostgauge.telltale import Telltale`); a helper sits beside the test file and is imported bare (`from helpers import assert_accepted`) or relatively. So a target now requires a dotted module path, and any name also defined in the test file is excluded outright — a local definition shadows the import, and a `pass`-bodied local must never read as production code.

Erring bare-is-a-helper errs toward **refusing**, which is the safe direction here: a false refusal costs a round, a false acceptance ships a suite that tests nothing. A genuinely flat single-module package would be read as a helper; nothing in the corpus imports that way, and the audit confirms it at 0 refusals.

`test_assertion_reading.py::test_the_must_not_raise_test_is_still_refused` also flipped, and it was written to. Its docstring said so: *"The ruling on whether absence-of-exception counts is #2754; until it lands, this test records the honest state rather than a number massaged to look finished."* It is now `..._is_now_accepted`.

## Measured on the artifact

`tools/answer_key_audit.py --repo boostgauge`:

| | before | after |
|---|---|---|
| verdicts | 50 | 50 |
| **refusals** | **1** | **0** |
| `impl.scaffold_suite_invalid` | ran 9, refused 1 | ran 9, refused **0** |

> Refusals — None. Every runnable gate accepted every shipped artifact.

## The regression this could most easily have caused

Widening "has an assertion" is exactly the change that could let run 8's hollow suite through — `run-issue4-163140`, whose approved spec shipped thirteen test functions after 605 seconds of spec work, and whose scaffolder validator refused the suite 3.4 s later, byte-identical on regeneration.

**It is still refused, and the count is 11 of 13, not 13 of 13.** The operator's brief said thirteen; measured, the fixture has thirteen functions of which **eleven** are a comment and `pass` — the other two carry real assertions. Eleven is what the validator named before this ruling and what it names after it. Two tests pin it: the aggregate `"11 of 13"` the check reports, and a direct assertion that not one of the thirteen bodies is read as calling into the code under test. A stub calls nothing at all, so it cannot.

## The other side of the line

A body that only touches fixtures and the standard library is refused:

```python
def test_only_touches_fixtures_and_stdlib(tmp_path, request):
    value = math.floor(3.7)
    request.config.getoption("--quiet")
```

`math` is stdlib, `request` is a fixture parameter, and neither is a target. `pass` and docstring-only bodies are refused as before.

## Where it lives

`impl.scaffold_suite_invalid`, which is where this judgement moved when #2792 retired the unreachable node the old row named. Nothing in the registry changes: **145 halt sites, 95 gates, impl 35, model-output 4**, all unchanged — this PR changes what a gate accepts, not which gates exist. The fail-open baseline's `sites_examined` moves 8798 → 8820 for the branches this adds, with `findings_total` unchanged at 534: no new fail-open site.

Closes #2754
