### PR TITLE
fix: give the implementation stage a derived step budget (Closes #2790)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1524,6 +1524,13 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
 
         # Run implementation workflow
         from assemblyzero.workflows.testing.graph import build_testing_workflow as create_impl_graph
+        # #2790: this stage spent no step budget, so its ceiling was
+        # LangGraph's default of 10007 -- ten thousand super-steps, in a stage
+        # where a super-step can be a model call, ending on an exception with
+        # no gate key. The budget is derived from the stage's own caps.
+        from assemblyzero.workflows.testing.step_budget import (
+            recursion_limit as impl_recursion_limit,
+        )
         from assemblyzero.workflows.testing.state import DEFAULT_MAX_ITERATIONS
 
         spec_path = state.get("spec_path", "")
@@ -1561,7 +1568,7 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # without a word.
             "max_iterations": DEFAULT_MAX_ITERATIONS,
             "config_mock_mode": mock_mode(state),
-        })
+        }, config={"recursion_limit": impl_recursion_limit(DEFAULT_MAX_ITERATIONS)})
 
         error_msg = sub_result.get("error_message", "")
         # #1779: the completeness gate's verdict must survive to the stage

--- a/assemblyzero/workflows/testing/step_budget.py
+++ b/assemblyzero/workflows/testing/step_budget.py
@@ -1,0 +1,88 @@
+"""How many super-steps the implementation stage may spend (#2790).
+
+The implementation-spec stage derives its own step budget and spends it; this
+stage passed none, so its ceiling was whatever LangGraph defaults to.
+
+**That default is 10007**, read from the installed package rather than from
+memory::
+
+    langgraph/_internal/_config.py:32
+    DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10007"))
+
+#2790 was filed saying 25, which was wrong and made the case sound like a
+converging run might trip an invisible ceiling. It cannot: 10007 is far above
+anything a converging run needs. The real cost is the other direction. A loop
+that escapes every internal cap runs **ten thousand super-steps** before
+LangGraph stops it, and in this stage a super-step can be a model call. The
+run then dies on `GraphRecursionError`, which carries no gate key, matches no
+registry row, and lands in the report as `unclassified`.
+
+So the budget here is not a safety margin for normal work. It is the distance
+between "a bug costs a few dozen steps and a named halt" and "a bug costs ten
+thousand steps and an exception nobody can attribute".
+
+Derived, never typed. Every term below is imported from the constant that
+actually bounds that loop, so raising a cap raises the budget with it and the
+two cannot drift. The spec stage's helper states the principle this follows:
+sized so the loop hits its own named halt -- the one that says which exit
+fired -- instead of a bound nothing states.
+"""
+
+from __future__ import annotations
+
+#: Slack for the paths this arithmetic does not enumerate: the HALT node, the
+#: END edge, a resumed run re-entering mid-graph, and any single-node detour
+#: added later that nobody remembers to count here. Deliberately generous --
+#: being wrong high costs a few super-steps of a runaway, being wrong low
+#: turns a legitimate run into a `GraphRecursionError`, which is the failure
+#: this module exists to prevent.
+HEADROOM_STEPS = 20
+
+
+def recursion_limit(max_iterations: int | None = None) -> int:
+    """Super-steps enough for every loop in the stage to reach its own cap.
+
+    Sized against the sum of the stage's caps rather than a guess, so the
+    first thing to stop a runaway is always a gate with a key.
+    """
+    from assemblyzero.workflows.testing.atlas import TOTAL_STEPS
+    from assemblyzero.workflows.testing.graph import (
+        MAX_COVERAGE_AUGMENT_ATTEMPTS,
+    )
+    from assemblyzero.workflows.testing.nodes.completeness_gate import (
+        MAX_COMPLETENESS_ITERATIONS,
+    )
+    from assemblyzero.workflows.testing.nodes.revise_test_plan import (
+        MAX_REVISION_CYCLES,
+    )
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        MAX_SCAFFOLD_ATTEMPTS,
+    )
+    from assemblyzero.workflows.testing.state import DEFAULT_MAX_ITERATIONS
+
+    iterations = DEFAULT_MAX_ITERATIONS if max_iterations is None else max_iterations
+
+    # The forward path, once: N0 through N9.
+    total = TOTAL_STEPS
+
+    # N1 -> N1.5 -> N1, once per test-plan revision.
+    total += MAX_REVISION_CYCLES * 2
+
+    # N3 -> N2 -> N2.5 -> N3, once per re-scaffold. #2767 made this loop
+    # bounded by MAX_SCAFFOLD_ATTEMPTS; before that it was bounded by nothing.
+    total += (MAX_SCAFFOLD_ATTEMPTS + 1) * 3
+
+    # N4b -> N4 -> N4b, once per completeness re-implementation.
+    total += MAX_COMPLETENESS_ITERATIONS * 2
+
+    # N5 -> N4 -> N4b -> N5, once per green iteration.
+    total += iterations * 3
+
+    # N5 -> N4c -> N5, once per coverage-augment attempt.
+    total += MAX_COVERAGE_AUGMENT_ATTEMPTS * 2
+
+    # N6 -> N4 -> N4b -> N5 -> N6, once per e2e iteration. Bounded by the same
+    # iteration cap the green loop reads.
+    total += iterations * 4
+
+    return total + HEADROOM_STEPS

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
-    "files_scanned": 309,
-    "sites_examined": 8820,
+    "files_scanned": 310,
+    "sites_examined": 8821,
     "findings_total": 534
   },
   "undeclared": [

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage rises above this, and when model_output_halt_rows differs from it in EITHER direction (#2759). A row that stops halting, or that leaves the model-output category, lowers the number in the same PR -- so the denominator is never stale. Raise either only with an operator ruling named in the row's created_by or justified_by, in the same PR.",
   "measured_against": {
-    "files_scanned": 184,
+    "files_scanned": 185,
     "halt_sites": 145,
     "gates": 95
   },

--- a/tests/unit/test_impl_step_budget.py
+++ b/tests/unit/test_impl_step_budget.py
@@ -1,0 +1,197 @@
+"""The implementation stage spends a derived step budget (#2790).
+
+It passed none, so its ceiling was LangGraph's default. That default is
+**10007**, read from the installed package rather than from memory:
+
+    langgraph/_internal/_config.py:32
+    DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10007"))
+
+#2790 was filed saying 25 and argued a converging run had zero margin at its
+iteration cap. That was wrong, and this suite pins the corrected claim
+instead: 10007 is far above anything a converging run needs, and the cost is
+a diverging one. A loop that escapes every internal cap runs ten thousand
+super-steps -- in this stage a super-step can be a model call -- and then
+dies on `GraphRecursionError`, which carries no gate key, matches no registry
+row, and lands in the report as `unclassified`.
+
+The budget is sized so every capped loop reaches its OWN named halt first,
+which is the principle the implementation-spec stage's helper states.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.step_budget import (
+    HEADROOM_STEPS,
+    recursion_limit,
+)
+
+#: What the installed LangGraph falls back to when nothing is passed.
+LANGGRAPH_DEFAULT = 10007
+
+
+class TestTheDefaultThisReplaces:
+    def test_the_default_is_read_from_the_package_not_from_memory(self):
+        """The number #2790 was filed on was wrong. This is where the right
+        one comes from, so the next reader does not have to trust prose."""
+        from langgraph._internal._config import DEFAULT_RECURSION_LIMIT
+
+        assert DEFAULT_RECURSION_LIMIT == LANGGRAPH_DEFAULT
+
+
+class TestTheBudgetIsDerived:
+    def test_it_is_far_below_the_default_it_replaces(self):
+        """The whole value: a runaway costs dozens of super-steps, not ten
+        thousand."""
+        assert recursion_limit() < LANGGRAPH_DEFAULT / 10
+
+    def test_raising_the_green_iteration_cap_raises_the_budget(self):
+        """Derived, not typed. A cap and the budget that has to accommodate it
+        cannot drift apart, because one is computed from the other."""
+        base = recursion_limit(5)
+        assert recursion_limit(6) > base
+        assert recursion_limit(6) - base == 7, (
+            "one more green iteration is 3 super-steps and one more e2e "
+            "iteration is 4; if that shape changed, the budget must follow"
+        )
+
+    def test_raising_the_scaffold_cap_raises_the_budget(self):
+        import assemblyzero.workflows.testing.nodes.validate_tests_mechanical as vtm
+
+        base = recursion_limit()
+        with patch.object(vtm, "MAX_SCAFFOLD_ATTEMPTS", vtm.MAX_SCAFFOLD_ATTEMPTS + 1):
+            raised = recursion_limit()
+        assert raised - base == 3, (
+            "one more re-scaffold is N3 -> N2 -> N2.5 -> N3"
+        )
+
+    def test_every_cap_the_stage_owns_is_accounted_for(self):
+        """A loop whose cap is missing from the sum is a loop that can be cut
+        short by the budget instead of stopped by its own gate -- the exact
+        failure this module exists to prevent."""
+        from assemblyzero.workflows.testing.atlas import TOTAL_STEPS
+        from assemblyzero.workflows.testing.graph import (
+            MAX_COVERAGE_AUGMENT_ATTEMPTS,
+        )
+        from assemblyzero.workflows.testing.nodes.completeness_gate import (
+            MAX_COMPLETENESS_ITERATIONS,
+        )
+        from assemblyzero.workflows.testing.nodes.revise_test_plan import (
+            MAX_REVISION_CYCLES,
+        )
+        from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+            MAX_SCAFFOLD_ATTEMPTS,
+        )
+
+        expected = (
+            TOTAL_STEPS
+            + MAX_REVISION_CYCLES * 2
+            + (MAX_SCAFFOLD_ATTEMPTS + 1) * 3
+            + MAX_COMPLETENESS_ITERATIONS * 2
+            + 5 * 3
+            + MAX_COVERAGE_AUGMENT_ATTEMPTS * 2
+            + 5 * 4
+            + HEADROOM_STEPS
+        )
+        assert recursion_limit(5) == expected
+
+
+class TestTheStageActuallySpendsIt:
+    def test_the_orchestrator_passes_the_derived_limit(self):
+        """A budget nobody passes is a comment. This is the assertion that
+        would have caught the original defect."""
+        import inspect
+
+        from assemblyzero.workflows.orchestrator import stages
+
+        source = inspect.getsource(stages)
+        assert "impl_recursion_limit(" in source, (
+            "the implementation stage does not pass a recursion_limit; its "
+            "ceiling is LangGraph's default again (#2790)"
+        )
+        assert 'config={"recursion_limit": impl_recursion_limit(' in source
+
+
+class TestACappedLoopStillReachesItsOwnHalt:
+    """The budget must not cut short a loop that has a gate waiting for it.
+
+    This drives the #2767 re-scaffold loop -- the longest capped loop in the
+    stage -- under the derived budget, and asserts it still ends on
+    `impl.scaffold_suite_invalid` rather than on the budget.
+    """
+
+    VALID_SUITE = (
+        "import pytest\n\n"
+        "from widget.core import combine\n\n\n"
+        "def test_combine_adds():\n"
+        "    assert combine(1, 2) == 3\n"
+    )
+
+    @pytest.fixture
+    def rolled(self, monkeypatch, tmp_path):
+        import assemblyzero.workflows.testing.graph as g
+
+        entries = {"scaffold": 0}
+
+        def fake_scaffold(state):
+            entries["scaffold"] += 1
+            return {
+                "generated_tests": self.VALID_SUITE + (
+                    f"\n\ndef test_extra_{entries['scaffold']}():\n"
+                    f"    assert combine({entries['scaffold']}, 0) "
+                    f"== {entries['scaffold']}\n"
+                ),
+                "parsed_scenarios": {"scenarios": [
+                    {"id": "S1", "description": "combine adds"},
+                ]},
+                "test_files": [str(tmp_path / "test_example.py")],
+                "error_message": "",
+            }
+
+        monkeypatch.setattr(g, "load_lld", lambda s: {
+            "lld_content": "# LLD\n", "spec_path": "spec.md", "error_message": ""})
+        monkeypatch.setattr(g, "review_test_plan", lambda s: {
+            "test_plan_status": "APPROVED", "error_message": ""})
+        monkeypatch.setattr(g, "scaffold_tests", fake_scaffold)
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.run_pytest",
+            lambda *a, **k: {
+                "returncode": 1, "stdout": "0 passed", "stderr": "",
+                "parsed": {"passed": 0, "failed": 0, "errors": 0, "coverage": 0},
+            },
+        )
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution",
+            lambda **k: None,
+        )
+        monkeypatch.setattr(
+            "assemblyzero.workflows.testing.nodes.verify_phases.Path.exists",
+            lambda self: True,
+        )
+
+        app = g.build_testing_workflow().compile()
+        final = app.invoke(
+            {
+                "issue_number": 4242,
+                "repo_root": str(tmp_path),
+                "worktree_path": str(tmp_path),
+                "audit_dir": "",
+                "max_iterations": 5,
+            },
+            config={"recursion_limit": recursion_limit(5)},
+        )
+        return final, entries
+
+    def test_it_ends_on_the_named_gate_not_the_budget(self, rolled):
+        final, _ = rolled
+        message = final.get("error_message", "")
+        assert "scaffold budget is spent" in message, message
+
+    def test_the_derived_budget_left_room_for_the_whole_loop(self, rolled):
+        """If the budget were too tight the fixture would have raised
+        GraphRecursionError before any assertion ran."""
+        _, entries = rolled
+        assert entries["scaffold"] >= 1


### PR DESCRIPTION
Ranked item 4: the remaining half of #2790. The reroute half closed with #2767, which gave the `N3 → N2` loop the bound it never had.

## First, the correction this PR is built on

#2790 says LangGraph's default recursion limit is **25** and argues the implementation stage has zero margin at its iteration cap. **That number was wrong** — I took it from memory rather than the installed package:

```
langgraph/_internal/_config.py:32
DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10007"))
```

Confirmed empirically while proving #2767: with the scaffold budget reverted, a re-scaffold loop died with `GraphRecursionError: Recursion limit of 10007 reached`.

So the zero-margin claim is void. A converging run is nowhere near the ceiling and never was. **The cost is the other direction**, and it is larger than the issue originally claimed: a loop that escapes every internal cap runs **ten thousand super-steps** — in this stage a super-step can be a model call — and then dies on an exception with no gate key, no registry row, and a place in the report under `unclassified`.

The corrected justification is on the issue. This PR is sized against it.

## What landed

`assemblyzero/workflows/testing/step_budget.py`, and the stage now spends it:

```python
sub_result = app.invoke({...},
    config={"recursion_limit": impl_recursion_limit(DEFAULT_MAX_ITERATIONS)})
```

**Derived, never typed.** Every term is imported from the constant that actually bounds that loop, so raising a cap raises the budget with it and the two cannot drift:

| loop | shape | bounded by |
|---|---|---|
| the forward path | `TOTAL_STEPS` | the atlas |
| `N1 → N1.5 → N1` | 2 per revision | `MAX_REVISION_CYCLES` |
| `N3 → N2 → N2.5 → N3` | 3 per re-scaffold | `MAX_SCAFFOLD_ATTEMPTS` (+1, per #2767's asymmetry) |
| `N4b → N4 → N4b` | 2 per iteration | `MAX_COMPLETENESS_ITERATIONS` |
| `N5 → N4 → N4b → N5` | 3 per iteration | the green iteration cap |
| `N5 → N4c → N5` | 2 per attempt | `MAX_COVERAGE_AUGMENT_ATTEMPTS` |
| `N6 → N4 → N4b → N5 → N6` | 4 per iteration | the same iteration cap |
| headroom | 20 | see below |

**Result at the default cap of 5 iterations: 94 super-steps, against 10007.** A runaway now costs roughly a hundredth of what it did.

Headroom is deliberately generous rather than tight. Being wrong high costs a few super-steps of a run that was already broken; being wrong low turns a legitimate run into the exact `GraphRecursionError` this module exists to prevent.

## What it does and does not promise

It does **not** make `GraphRecursionError` impossible. A loop with no cap at all still ends there — just at 94 instead of 10007. What the sizing guarantees is that every loop which *has* a gate reaches that gate first, which is the principle the implementation-spec stage's helper already states: *sized so the loop hits its own named halt — the one that says which exit fired — instead of a bound nothing states.*

Stating that plainly matters, because "never on GraphRecursionError" is not a promise arithmetic can make.

## Tests

Eight, and the two that would have caught the original defect:

- **The default is read from the package**, not asserted from prose — so the next reader does not have to trust that 10007 is right.
- **The orchestrator actually passes the limit.** A budget nobody spends is a comment; this is the assertion whose absence let the stage run uncapped.
- Raising the green iteration cap moves the budget by exactly 7 (3 green + 4 e2e); raising the scaffold cap moves it by exactly 3.
- Every cap the stage owns appears in the sum — a loop missing from it is a loop the budget could cut short instead of its own gate stopping it.
- **A capped loop still reaches its own halt under the derived budget:** the #2767 re-scaffold loop, the longest in the stage, rolled on the real compiled graph with `recursion_limit=94`, still ending on `impl.scaffold_suite_invalid` rather than on the budget.

## Not measured

No recorded run has hit the bound. I grepped all 802 run logs for `GraphRecursionError` and for `recursion limit`: zero hits. This is a latent cost made smaller, not an observed failure fixed, and the report says so.

Registry untouched: **145 halt sites, 95 gates, impl 35, model-output 4**.

Closes #2790
