### PR TITLE
fix: pair every single-site row to its own return (Closes #2776)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -1207,6 +1207,74 @@ def unregistered(
     return [site for site in sites if site.key not in known]
 
 
+#: Site kinds whose head the WALKER synthesises rather than reads out of the
+#: code. `refusal` sites get the literal string "pinning refusal"; it appears
+#: in no source file and never will, so a text rule cannot be asked about them.
+_SYNTHETIC_HEAD_KINDS: frozenset[str] = frozenset({KIND_REFUSAL, KIND_CONSERVATION})
+
+
+#: Single-site rows whose site head the WALKER reads wrongly, not rows that
+#: are wrong (#2776). Each entry is a defect in `_static_head`, not in the
+#: registry, and #2814 is where they get fixed; every one should disappear.
+EMITS_HEAD_EXEMPTIONS: dict[str, str] = {
+    "impl.deterministic_failure": (
+        "the return is f\"{DETERMINISTIC_FAILURE}: {message}\", so the static "
+        "head is literally '{}: {}' and carries no text to compare"
+    ),
+    "spec.review_blocked": (
+        "the return interpolates three values and no literal words survive; "
+        "head is '{}\\n  exit: {}\\n  {}'"
+    ),
+    "spec.edit_script_rejected": (
+        "the return is _spec_edit_halt(halt_reason), and _static_head takes a "
+        "call's first literal ARGUMENT rather than following into the callee, "
+        "so it reads the reason ('every edit touched locked content...') "
+        "instead of the wrapper's '[EDIT-SCRIPT] spec revision rejected' "
+        "prefix. The row is right and the head is wrong"
+    ),
+}
+
+
+def mismatched_emits(
+    sites: list[HaltSite], registry: tuple[Gate, ...] = ()
+) -> list[tuple[str, str, str]]:
+    """(gate key, emits, head) where a row's message is not its site's (#2776).
+
+    The two-way check proves every site is named and every name exists.
+    Neither notices a row naming the WRONG return: retire a gate, add a return
+    at the end, and the surviving row owns a return it has nothing to do with,
+    with no phantom to give it away. Only comparing the row's message to THAT
+    SITE's head catches it.
+
+    Measured before it was written, because the obvious wider forms do not
+    work. Over the whole named set, `emits`-in-head fails 42 of 128 readable
+    sites -- a row covering five returns can only name one of their messages.
+    A source-text rule (is `emits` written in the function the site is in, or
+    in what `decided_in` names) reads 0 of 81 and is therefore worthless HERE:
+    both the right and the wrong return live in the same function, so it
+    passes the very case this exists to catch. A check that cannot fail on
+    its own scenario is the defect, not the guard.
+
+    So: single-site rows only, where `emits` and the head are answerable
+    one-to-one. That is 51 of the 81 rows with sites. The other 30 are
+    multi-site rows, whose `emits` names one of several messages by design,
+    and two rows whose only site has an unreadable head.
+    """
+    found: list[tuple[str, str, str]] = []
+    by_key = {s.key: s for s in sites}
+    for gate in (registry or GATE_REGISTRY):
+        if len(gate.sites) != 1 or gate.key in EMITS_HEAD_EXEMPTIONS:
+            continue
+        site = by_key.get(gate.sites[0])
+        if site is None or site.kind in _SYNTHETIC_HEAD_KINDS:
+            continue
+        if site.head.startswith("<"):
+            continue
+        if gate.emits not in site.head:
+            found.append((gate.key, gate.emits, site.head))
+    return sorted(found)
+
+
 def phantoms(
     sites: list[HaltSite], registry: tuple[Gate, ...] = ()
 ) -> list[tuple[str, str]]:

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 308,
-    "sites_examined": 8791,
+    "sites_examined": 8796,
     "findings_total": 533
   },
   "undeclared": [

--- a/tests/unit/test_emits_pairing.py
+++ b/tests/unit/test_emits_pairing.py
@@ -1,0 +1,162 @@
+"""A row must name the return it actually describes (#2776).
+
+The registry's two-way check proves every walked site is named by a row and
+every site a row names exists. Both hold while a row points at the **wrong
+return**, and the issue's six-line reproduction is why:
+
+Take a function with four halting returns, registered `::0` through `::3`.
+Retire the third gate and add a new return at the end. The function has four
+returns again, index 3 now holds the NEW one, and the row that owned the old
+fourth return still names index 3. No phantom — index 3 exists. One
+unregistered site — index 2, which shifted down. `--check` reports one
+finding and it is the wrong one, while a row sits attached to a return it has
+nothing to do with.
+
+`mismatched_emits` compares the row's message to THAT SITE's head, which is
+the only comparison that catches it.
+
+**Two wider rules were measured first and rejected, and the numbers are here
+so nobody re-proposes them.**
+
+*`emits`-in-head over every named site* fails **42 of 128** readable sites. A
+row covering five returns can only name one of their messages, so most of the
+42 are correct rows. The issue measured 56 of 151 on an older tree.
+
+*A source-text rule* — is `emits` written in the function the site sits in, or
+in what `decided_in` names — reads **0 of 81** rows, and is worthless for this
+purpose. Both the right and the wrong return live in the SAME function, so it
+passes the exact scenario above. It was built, measured, and deleted. A check
+that cannot fail on its own case is the defect, not the guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.gate_registry import (
+    ACTION_HALT,
+    EMITS_HEAD_EXEMPTIONS,
+    GATE_REGISTRY,
+    JUDGES_MODEL_OUTPUT,
+    Gate,
+    mismatched_emits,
+    registry_by_key,
+    scan_halt_sites,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def walked():
+    sites, coverage = scan_halt_sites(REPO_ROOT)
+    assert coverage.files_scanned > 0
+    return sites
+
+
+class TestTheTreeIsPaired:
+    def test_no_single_site_row_names_someone_elses_return(self, walked):
+        bad = mismatched_emits(walked)
+        assert not bad, "\n".join(
+            f"{key}: emits {emits!r} but its only site's head is {head[:70]!r}"
+            for key, emits, head in bad
+        )
+
+    def test_the_check_covers_most_of_the_registry(self, walked):
+        """A guard is only worth what it looks at, so the denominator is
+        asserted rather than left to be discovered as near-zero later."""
+        checked = [
+            g for g in GATE_REGISTRY
+            if len(g.sites) == 1 and g.key not in EMITS_HEAD_EXEMPTIONS
+        ]
+        with_sites = [g for g in GATE_REGISTRY if g.sites]
+        assert len(checked) >= 45, (
+            f"only {len(checked)} of {len(with_sites)} rows with sites are "
+            f"under the pairing check; it has stopped being worth running"
+        )
+
+
+class TestItCatchesTheIssuesOwnScenario:
+    """Discrimination, on the reproduction #2776 wrote out.
+
+    Every check retired this week was one that could not fail. This one is
+    watched failing on the case it exists for, with a synthetic registry so
+    the real one is untouched.
+    """
+
+    def _tree(self, tmp_path: Path) -> Path:
+        module = tmp_path / "assemblyzero" / "workflows" / "fake" / "node.py"
+        module.parent.mkdir(parents=True)
+        module.write_text(
+            "\n".join(
+                [
+                    "def n(state):",
+                    "    if state.get('a'):",
+                    "        return {'error_message': 'ALPHA: first'}",
+                    "    if state.get('b'):",
+                    "        return {'error_message': 'BETA: second'}",
+                    "    return {'error_message': ''}",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def _row(self, emits: str, index: int) -> Gate:
+        return Gate(
+            "fake.row", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT, emits,
+            (f"assemblyzero/workflows/fake/node.py::n::return::{index}",),
+        )
+
+    def test_a_row_naming_the_wrong_return_is_caught(self, tmp_path):
+        sites, _ = scan_halt_sites(self._tree(tmp_path))
+        bad = mismatched_emits(sites, (self._row("ALPHA", 1),))
+        assert [k for k, _, _ in bad] == ["fake.row"]
+        assert bad[0][2] == "BETA: second", bad
+
+    def test_the_same_row_naming_its_own_return_passes(self, tmp_path):
+        sites, _ = scan_halt_sites(self._tree(tmp_path))
+        assert mismatched_emits(sites, (self._row("ALPHA", 0),)) == []
+
+    def test_the_two_way_check_would_not_have_noticed(self, tmp_path):
+        """Why this check had to exist: the wrong name is not a phantom.
+
+        The site the row points at is real, so `phantoms` is empty and
+        nothing in the existing pair of checks fires.
+        """
+        from assemblyzero.core.gate_registry import phantoms
+
+        sites, _ = scan_halt_sites(self._tree(tmp_path))
+        assert phantoms(sites, (self._row("ALPHA", 1),)) == []
+
+
+class TestTheExemptionsAreHonest:
+    def test_each_names_a_real_row(self):
+        keys = registry_by_key()
+        for key in EMITS_HEAD_EXEMPTIONS:
+            assert key in keys, f"{key} is exempted but not in the registry"
+
+    def test_each_says_why(self):
+        for key, reason in EMITS_HEAD_EXEMPTIONS.items():
+            assert len(reason.strip()) > 40, f"{key}: {reason!r}"
+
+    def test_each_is_a_walker_defect_and_not_a_row_defect(self, walked):
+        """An exemption is only legitimate while the HEAD is what is wrong.
+
+        Every entry is a row whose site head fails to carry the message the
+        code really emits -- an interpolation that leaves no words, or a call
+        whose argument the walker reads instead of its callee. #2814 fixes
+        those readings; when one lands, its row stops needing an exemption
+        and this asserts the entry is gone.
+        """
+        by_key = {s.key: s for s in walked}
+        for key in EMITS_HEAD_EXEMPTIONS:
+            gate = registry_by_key()[key]
+            site = by_key.get(gate.sites[0])
+            assert site is not None, f"{key} exempted but its site is gone"
+            assert gate.emits not in site.head, (
+                f"{key} no longer needs its exemption -- its head now carries "
+                f"{gate.emits!r}. Remove the entry (#2814)."
+            )

--- a/tests/unit/test_gate_registry.py
+++ b/tests/unit/test_gate_registry.py
@@ -727,8 +727,9 @@ class TestEveryNodeModuleIsReachable:
     satisfied by a re-export. `validate_commit_message` was imported by
     `testing/nodes/__init__.py` and by nothing else, so it counted as
     reachable while no graph declared it as a node -- dead code this check
-    would have passed. #2787 retired it and filed the stronger check, which
-    asks whether a module supplies a node rather than whether it is imported.
+    would have passed. #2787 retired it on a measurement built by hand: build
+    every graph and enumerate its node names. The stronger check -- does this
+    module SUPPLY a node, rather than merely get imported -- is #2813.
     """
 
     def test_every_node_module_is_pulled_in_by_some_graph(self):

--- a/tools/audit_halt_sites.py
+++ b/tools/audit_halt_sites.py
@@ -32,11 +32,13 @@ _install_utf8_console()
 
 from assemblyzero.core.gate_registry import (  # noqa: E402
     ACTION_HALT,
+    EMITS_HEAD_EXEMPTIONS,
     GATE_REGISTRY,
     JUDGES_MODEL_OUTPUT,
     HaltSite,
     WalkCoverage,
     halt_counts,
+    mismatched_emits,
     renumberings,
     scan_halt_sites,
     site_to_gate,
@@ -179,14 +181,25 @@ def main(argv: list[str] | None = None) -> int:
         # check then reports the neighbours while saying nothing about the gate
         # that moved. In #2723 it named four gates that had not been touched.
         moved, fresh, ghosts = renumberings(sites)
-        if not fresh and not ghosts and not moved:
+        # #2776: a row can name a return that exists and is not its own, which
+        # neither direction of the two-way check can see. Compared here so a
+        # wrong pairing fails the same command an unregistered site does.
+        unpaired = mismatched_emits(sites)
+        if not fresh and not ghosts and not moved and not unpaired:
+            paired = sum(
+                1 for g in GATE_REGISTRY
+                if len(g.sites) == 1 and g.key not in EMITS_HEAD_EXEMPTIONS
+            )
             print(
                 f"PASS -- {coverage.files_scanned} files, {len(sites)} halt "
                 f"sites, every one registered; {len(GATE_REGISTRY)} gates, "
-                f"halt rows: {halt_counts()}"
+                f"halt rows: {halt_counts()}; {paired} row(s) paired to their "
+                f"own return, {len(EMITS_HEAD_EXEMPTIONS)} exempt (#2814)"
             )
             return 0
         parts = []
+        if unpaired:
+            parts.append(f"{len(unpaired)} mispaired row(s)")
         if moved:
             parts.append(f"{len(moved)} renumbered site(s)")
         if fresh:
@@ -202,6 +215,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {rename.describe()}")
                 print(f"    {rename.named}")
                 print(f"    -> {rename.found}")
+        for gate_key, emits, head in unpaired:
+            print(f"  mispaired: {gate_key} claims {emits!r}")
+            print(f"    but its only site's head is {head[:70]!r}")
         for site in fresh:
             print(f"  unregistered: {site.key}  line {site.line}  {site.head[:70]!r}")
         for gate_key, site in ghosts:


### PR DESCRIPTION
A row must name the return it actually describes, and `--check` now says so.

Closes #2776

## What was wrong

The registry's two-way check proves every walked site is named by a row and every site a row names exists. Both hold while a row points at the **wrong return**. The issue's reproduction: a function with four halting returns registered `::0`–`::3`; retire the third gate and add a return at the end; index 3 now holds the *new* return and the row that owned the old fourth still names it. No phantom, because index 3 exists. One unregistered site, index 2, which shifted down. `--check` reports one finding and it is the wrong one, while a row sits attached to a return it has nothing to do with — counted by the audit's per-gate table, by the ratchet, and joined to a death by the terminal record, all under a key describing a different gate.

## Two wider rules were measured first and rejected

Both numbers are in the test file's docstring so nobody re-proposes them.

**`emits`-in-head over every named site fails 42 of 128 readable sites.** A row covering five returns can only name one of their messages, so most of those are correct rows. (The issue measured 56 of 151 on an older tree; re-derived today.)

**A source-text rule reads 0 of 81 rows and is worthless here.** I built it — is `emits` written in the function the site sits in, in a module constant that function references, or in what `decided_in` names — got it to zero on the real tree, and then deleted it, because **both the right and the wrong return live in the same function**. It passes the exact scenario this issue is about. A check that cannot fail on its own case is the defect, not the guard, and shipping it would have been the same "row that describes code that never runs" this week already retired four times.

## What shipped

`mismatched_emits` compares a row's `emits` to **that site's** head, for single-site rows only — where the two are answerable one-to-one. **50 of the 81 rows with sites** are under it. The remaining 31 are 28 multi-site rows, whose `emits` names one of several messages by design, and three exemptions.

Wired into `audit_halt_sites.py --check`, so a mispairing fails the same command an unregistered site does, and the PASS line now carries the denominator:

```
PASS -- 183 files, 142 halt sites, every one registered; 93 gates,
halt rows: {...}; 50 row(s) paired to their own return, 3 exempt (#2814)
```

## The three exemptions are walker defects, not row defects

Each is a row whose site head fails to carry the message the code really emits, and each is filed as **#2814**:

- `spec.edit_script_rejected` — the return is `_spec_edit_halt(halt_reason)`, and `_static_head` takes a call's first literal **argument** rather than following into the callee. It reads the reason (`"every edit touched locked content..."`) instead of the wrapper's `"[EDIT-SCRIPT] spec revision rejected"` prefix. The row is right; the head is wrong.
- `impl.deterministic_failure` — returns `f"{DETERMINISTIC_FAILURE}: {message}"`, so the head is literally `'{}: {}'` and carries no text to compare. This is the case the instruction predicted could not be satisfied, and it is why the check reads the head rather than the source: source would pass it and pass the mispairing too.
- `spec.review_blocked` — three interpolations, no literal words survive.

A test asserts each exemption still *needs* to be one: when #2814 makes a head carry its message, that row's entry has to be deleted or the suite fails. The table cannot fossilise.

## Tests

`tests/unit/test_emits_pairing.py`, 8 tests.

- **The tree is paired** — no single-site row names someone else's return.
- **The check covers most of the registry** — the denominator is asserted (≥45 rows), so it cannot quietly decay into looking at nothing.
- **It catches the issue's own scenario** — the reproduction built as a fixture tree with a synthetic registry: a row naming index 1 while claiming index 0's message is caught, the same row naming its own return passes, and `phantoms` is asserted **empty** on the mispaired case, which is the whole reason this check had to exist.
- **The exemptions are honest** — each names a real row, says why at length, and is verified to still be a walker defect.

Full unit suite run in the worktree; ruff clean on every file touched.

## One correction to the record, in passing

`tests/unit/test_gate_registry.py` shipped in #2812 saying #2787 "filed the stronger check". It had not been filed. It is **#2813** now, and the sentence names it. That was my error and it is the kind this whole issue is about — an artifact asserting something about itself that was not true.
