### PR TITLE
fix: give the test plan three revision cycles, not two (Closes #2815)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -569,7 +569,7 @@ GATE_REGISTRY: tuple[Gate, ...] = (
             "only because it fired on the FIRST short revision: the return "
             "recorded a reason, and since #2793 a recorded reason routes to "
             "HALT, so route_after_review never reached its revise branch and "
-            "MAX_REVISION_CYCLES = 2 was unreachable from this site -- the "
+            "MAX_REVISION_CYCLES was unreachable from this site -- the "
             "cap was dead code. The site now records no reason under the cap "
             "and the N1 <-> N1.5 loop runs; what is left here is the "
             "allowance running out, which is a budget"

--- a/assemblyzero/workflows/testing/nodes/revise_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/revise_test_plan.py
@@ -3,7 +3,7 @@
 When N1 (review_test_plan) returns BLOCKED, the workflow used to END.
 With this node in the graph, the BLOCKED feedback is fed back to an
 LLM revisor that produces a fresh Test Scenarios table; the loop then
-returns to N1 for re-review. Hard cap: 2 revision cycles before END.
+returns to N1 for re-review, bounded by `MAX_REVISION_CYCLES` below.
 
 The revisor is invoked via the same provider abstraction as N1 with
 the #1071 retry policy, so transient failures during revision retry
@@ -23,9 +23,20 @@ from assemblyzero.workflows.testing.state import TestingWorkflowState
 logger = logging.getLogger(__name__)
 
 
-# Maximum revision cycles before END. Hard cap prevents infinite loops
-# when the LLM cannot fix the underlying issue. Per #1072 acceptance.
-MAX_REVISION_CYCLES = 2
+# Maximum revision cycles before the budget ends the run. Hard cap prevents
+# infinite loops when the LLM cannot fix the underlying issue.
+#
+# #1072 set this to 2 and nothing ever exercised the second cycle, because
+# until #2775 the loop could not reach it: this node recorded a reason on the
+# FIRST short revision, and a recorded reason routes to HALT. The cap was
+# dead code for as long as it existed, so its number was never tested.
+#
+# 3 since #2815 (operator, 2026-09-05). With the loop actually running, the
+# acceptance this work was scoped against is a plan that comes back short
+# twice and complete on the third pass, which needs three cycles rather than
+# two. `step_budget.recursion_limit` imports this constant instead of
+# repeating it, so the graph's step allowance follows automatically.
+MAX_REVISION_CYCLES = 3
 
 
 # Pattern: T001 / T1 / 001 — captured by the same regex used in

--- a/tests/unit/test_test_plan_revision_budget.py
+++ b/tests/unit/test_test_plan_revision_budget.py
@@ -10,7 +10,7 @@ since #2793 a recorded reason routes to HALT. `route_after_review` checks the
 error before it checks anything else, so the run ended on the FIRST short
 revision and never reached the branch that sends it back to N1.5. The comment
 above that return said "increment count and let the router decide whether to
-retry or END"; the router never decided. `MAX_REVISION_CYCLES = 2` was
+retry or END"; the router never decided. `MAX_REVISION_CYCLES` was
 unreachable from this site for as long as the site has existed.
 
 **The fix.** Under the cap, record no reason. At the cap, record one that
@@ -19,8 +19,14 @@ under ruling 1 of #2723: what ends the run is the allowance running out, not
 a verdict on what the drafter wrote.
 
 Note on the arithmetic, stated rather than assumed: `MAX_REVISION_CYCLES` is
-**2**, set by #1072. So a run gets two revision cycles, and the second short
-one is the one that halts. These tests are written against the shipped cap.
+**3** (#2815, operator ruling 2026-09-05). #1072 set it to 2 and nothing ever exercised
+the second cycle, because until #2775 the loop could not reach it at all --
+so the number in that constant had never once been tested. With the loop
+running, the acceptance is a plan that comes back short twice and complete on
+the third pass, which needs three.
+
+Every assertion below reads the constant rather than a literal, so the cap
+can move again without rewriting the suite.
 """
 
 from __future__ import annotations
@@ -128,7 +134,7 @@ class TestTheNodeItself:
         assert str(MAX_REVISION_CYCLES) in message, (
             "the message must say how large the allowance was"
         )
-        assert "1/2" in message, (
+        assert f"1/{len(REQUIREMENTS)}" in message, (
             "and how short the plan still is, so a reader knows which side "
             "to repair"
         )


### PR DESCRIPTION
The test plan gets three revision cycles, and the number is now one that has been exercised.

Closes #2815

## Why 2 was never a decision

`MAX_REVISION_CYCLES` has been 2 since #1072. Nothing ever ran the second cycle, because until #2775 the loop could not reach it: `revise_test_plan` recorded an `error_message` on the **first** short revision, and since #2793 a recorded reason routes to HALT, so `route_after_review` never got to its revise branch. The cap was dead code for as long as it existed.

So the 2 is not a tested number someone chose and validated. It is a number that has never once decided anything.

## Why 3

The acceptance this work was scoped against is a plan that comes back short twice and complete on the third pass, and one that comes back short three times halting at the cap. That needs three cycles. With two, the third pass never happens and a plan one revision from complete is thrown away — which was invisible while the loop was broken and becomes real the moment it runs.

The cost is one extra reviser call in the worst case, on a stage that spends far more on the draft itself.

## What follows automatically, and what does not

`step_budget.recursion_limit` **imports** this constant rather than repeating it, so the graph's super-step allowance moves with the cap. `tests/unit/test_impl_step_budget.py` asserts that relationship and passes **without being edited**, which is the evidence the budget follows rather than duplicates. That is the one thing worth checking in this diff.

Every assertion about the cap now reads the constant instead of a literal, so the next change to it does not require rewriting the suite. Two prose references to `MAX_REVISION_CYCLES = 2` are gone — the `impl.test_plan_revision_incomplete` row's note and the test module docstring — along with a third in the node's own module docstring, which said "Hard cap: 2 revision cycles before END" and now points at the constant.

## Verification

Full unit suite: **10025 passed**. No ratchet number moves: 177 files, 142 halt sites, 93 gates, halt rows unchanged.
