### PR TITLE
feat: count the infrastructure a run survives (Closes #2810)

### DIFF
--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -97,6 +97,34 @@ _RE_EDIT_APPLIED = re.compile(r"\[EDIT-SCRIPT\]\s+Applied\s+(?P<edits>\d+)\s+edi
 _RE_EDIT_FALLBACK = re.compile(
     r"\[EDIT-SCRIPT\]\s+Falling back to full revision:\s*(?P<reason>.*)"
 )
+#: One retry attempt that failed, with the reason it gives. #2810: the cause
+#: table answers "what killed this run", so an infrastructure failure a run
+#: SURVIVES leaves no trace anywhere -- and a run can spend its entire
+#: edit-script allowance on one, recover, and die later of something else.
+_RE_ATTEMPT_FAILED = re.compile(
+    r"\[EDIT-SCRIPT\]\s+attempt\s+(?P<n>\d+)/(?P<of>\d+)\s+failed\s+"
+    r"\((?P<reason>[^)]*)"
+)
+
+#: Which survived reasons are infrastructure, and what to call them. Closed
+#: and authored, never discovered: an unmatched reason counts as
+#: `survived.unclassified` and is printed verbatim rather than folded into a
+#: neighbour -- the same rule the cause table follows.
+SURVIVED_EVENT_KINDS: tuple[tuple[str, str], ...] = (
+    ("drafter call failed", "infra.drafter_unreachable"),
+)
+SURVIVED_UNCLASSIFIED = "survived.unclassified"
+
+
+def classify_survived(reason: str) -> str:
+    """The key for a retry failure a run walked away from (#2810)."""
+    head = (reason or "").strip()
+    for prefix, key in SURVIVED_EVENT_KINDS:
+        if head.startswith(prefix):
+            return key
+    return SURVIVED_UNCLASSIFIED
+
+
 _RE_CAP_GRANT = re.compile(r"\[CAP\]\s+(?P<detail>.*)")
 _RE_REVIEW_ROUND = re.compile(
     r"\[REVIEW\]\s+(?P<what>\S+)\s+review\s+\S+\s+\[(?P<verdict>[^\]]+)\]:"
@@ -521,6 +549,11 @@ class RunLogFacts:
     edit_script_fallbacks: int = 0
     fallback_reasons: list[str] = field(default_factory=list)
     cap_grants: list[str] = field(default_factory=list)
+    #: #2810: (key, reason, attempt, of) for every retry attempt that failed
+    #: and that the run then walked away from. Not a cause of death -- these
+    #: runs continued -- but a budget spent on something the report otherwise
+    #: never mentions.
+    survived_events: list[tuple[str, str, int, int]] = field(default_factory=list)
     review_rounds: dict[str, int] = field(default_factory=dict)
     #: stage -> (max observed elapsed, nominal). The watchdog prints one
     #: line per minute per stage, so the LAST elapsed for a stage is the
@@ -635,6 +668,15 @@ def scan_run_log(path: Path) -> RunLogFacts:
             reason = fallback.group("reason").strip()
             if reason:
                 facts.fallback_reasons.append(reason[:120])
+        attempt = _RE_ATTEMPT_FAILED.search(line)
+        if attempt:
+            reason = attempt.group("reason").strip()
+            facts.survived_events.append((
+                classify_survived(reason),
+                reason[:120],
+                int(attempt.group("n")),
+                int(attempt.group("of")),
+            ))
         cap = _RE_CAP_GRANT.search(line)
         if cap:
             facts.cap_grants.append(cap.group("detail").strip()[:160])
@@ -963,6 +1005,15 @@ def _top(counter: dict[str, int], limit: int = 3) -> list[tuple[str, int]]:
     return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
 
 
+def _survived_index(runs: list[RunLogFacts]) -> dict[str, list[str]]:
+    """key -> one line per survived retry failure, run id first (#2810)."""
+    index: dict[str, list[str]] = defaultdict(list)
+    for facts in runs:
+        for key, reason, n, of in facts.survived_events:
+            index[key].append(f"{facts.run_id}: attempt {n}/{of} -- {reason}")
+    return {k: sorted(v) for k, v in sorted(index.items())}
+
+
 def build_report(
     repo_root: Path | str,
     *,
@@ -1179,6 +1230,11 @@ def build_report(
             "edit_script_fallbacks": fallback_total,
             "fallback_reasons": _top(fallback_reasons, 5),
         },
+        # #2810: infrastructure a run SURVIVED, keyed the way causes are but
+        # kept out of the cause table on purpose -- these runs did not die of
+        # this, and a non-death in the deaths table would move a distribution
+        # nobody decided to move.
+        "survived": _survived_index(runs),
         "pinning": {
             "refusals": pinning_refusals,
             "regressions": pinning_regressions,
@@ -1414,6 +1470,31 @@ def render_report(data: dict) -> str:
         lines.append("")
 
     loops = data["loops"]
+    # #2810: infrastructure a run SURVIVED. Deliberately its own section and
+    # not a cause row -- these runs did not die of this, and putting a
+    # non-death in the deaths table would move a distribution nobody decided
+    # to move. What it shows is a budget consumed before the work began.
+    survived = data.get("survived", {})
+    lines.append("## Infrastructure a run survived (#2810)")
+    lines.append("")
+    if not survived:
+        lines.append("None recorded.")
+    else:
+        spent = sum(len(v) for v in survived.values())
+        runs_hit = {e.split(":")[0] for v in survived.values() for e in v}
+        lines.append(
+            f"{spent} retry attempt(s) across {len(runs_hit)} run(s) failed "
+            f"for a reason the run then recovered from. These are NOT causes "
+            f"of death and appear in no cause row: a run can spend its whole "
+            f"allowance here, continue, and die later of something else."
+        )
+        lines.append("")
+        for key in sorted(survived):
+            lines.append(f"- `{key}` -- {len(survived[key])} attempt(s)")
+            for entry in survived[key]:
+                lines.append(f"    - {entry}")
+    lines.append("")
+
     lines.append("## Loops: revision rounds, caps, edit-script health")
     lines.append("")
     applied = loops["edit_scripts_applied"]

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 308,
-    "sites_examined": 8791,
+    "sites_examined": 8797,
     "findings_total": 533
   },
   "undeclared": [

--- a/tests/unit/test_survived_infrastructure.py
+++ b/tests/unit/test_survived_infrastructure.py
@@ -1,0 +1,102 @@
+"""Infrastructure a run walked away from is counted (#2810).
+
+`factory_report`'s cause table answers one question: what killed this run.
+An infrastructure failure a run SURVIVES therefore leaves no trace anywhere
+— and a run can spend its entire retry allowance on one, recover, and die
+later of something unrelated.
+
+`run-issue41-184913` is the exhibit. Three of three edit-script attempts
+failed with `drafter call failed: All credentials failed via agy`; the run
+continued, drew a fresh revision, and died two hundred lines later for a
+different reason. The report attributed it correctly and said nothing about
+the budget that had already been spent before the work began.
+
+**Deliberately not a cause row.** Putting a non-death in the deaths table
+would move a distribution nobody decided to move, so this is its own
+section and `test_no_cause_of_death_count_moves` pins that.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.speedrun.factory_report import (
+    SURVIVED_UNCLASSIFIED,
+    RunLogFacts,
+    _survived_index,
+    classify_survived,
+)
+
+CREDENTIALS = "drafter call failed: All credentials failed via agy (Antigravity CLI"
+
+
+def _facts(run_id: str, events) -> RunLogFacts:
+    return RunLogFacts(
+        run_id=run_id, issue=41, path=f"{run_id}.log", mtime="x",
+        survived_events=list(events),
+    )
+
+
+class TestClassification:
+    def test_a_credentials_failure_is_infrastructure(self):
+        assert classify_survived(CREDENTIALS) == "infra.drafter_unreachable"
+
+    def test_an_unknown_reason_is_named_not_absorbed(self):
+        """The cause table's own rule: never the nearest bucket."""
+        assert classify_survived("something nobody has seen") == (
+            SURVIVED_UNCLASSIFIED
+        )
+
+    def test_an_empty_reason_is_still_classified_rather_than_dropped(self):
+        assert classify_survived("") == SURVIVED_UNCLASSIFIED
+
+
+class TestTheIndex:
+    def test_it_groups_by_key_and_names_the_run_and_the_attempt(self):
+        index = _survived_index([
+            _facts("run-a", [("infra.drafter_unreachable", CREDENTIALS, 1, 3)]),
+            _facts("run-b", [
+                ("infra.drafter_unreachable", CREDENTIALS, 1, 3),
+                ("infra.drafter_unreachable", CREDENTIALS, 2, 3),
+            ]),
+        ])
+        assert list(index) == ["infra.drafter_unreachable"]
+        entries = index["infra.drafter_unreachable"]
+        assert len(entries) == 3
+        assert entries[0].startswith("run-a: attempt 1/3 -- ")
+        assert any("run-b: attempt 2/3" in e for e in entries)
+
+    def test_a_run_that_survived_nothing_contributes_nothing(self):
+        assert _survived_index([_facts("clean", [])]) == {}
+
+    def test_the_whole_allowance_being_spent_is_visible(self):
+        """The finding this exists for: 3 of 3, and the run lived.
+
+        A reader sizing that cap needs to see its most expensive customer,
+        and no cause row will ever show it.
+        """
+        index = _survived_index([
+            _facts("run-issue41-184913", [
+                ("infra.drafter_unreachable", CREDENTIALS, n, 3)
+                for n in (1, 2, 3)
+            ]),
+        ])
+        entries = index["infra.drafter_unreachable"]
+        assert len(entries) == 3
+        assert entries[-1].endswith(CREDENTIALS)
+        assert "attempt 3/3" in entries[-1]
+
+
+class TestItStaysOutOfTheDeathsTable:
+    def test_survived_events_are_not_a_cause_and_have_no_row(self):
+        """A survived event must never acquire a `Cause` row: the cause
+        table is about deaths, and this run did not die of it."""
+        from assemblyzero.speedrun.factory_report import CAUSE_TABLE
+
+        keys = {c.key for c in CAUSE_TABLE}
+        assert "infra.drafter_unreachable" not in keys
+        assert SURVIVED_UNCLASSIFIED not in keys
+
+    def test_the_parser_field_defaults_empty(self):
+        """So a log with no such line is indistinguishable from before."""
+        assert RunLogFacts(
+            run_id="x", issue=None, path="x", mtime="x",
+        ).survived_events == []


### PR DESCRIPTION
Infrastructure a run walks away from is now counted, and it is deliberately not a cause of death.

Closes #2810

## The gap

`factory_report`'s cause table answers exactly one question: what killed this run. So an infrastructure failure a run **survives** leaves no trace anywhere — and a run can spend its entire retry allowance on one, recover, and die later of something unrelated.

`run-issue41-184913` is the exhibit, and it is the run whose misreading #2784 was filed on. Three of three edit-script attempts failed with `drafter call failed: All credentials failed via agy`; the run continued, drew a fresh revision, and died two hundred lines later for a different reason. The report attributed the death correctly and said nothing about the budget already spent before the work began.

## Measured, over the whole window

**4 attempts across 2 runs**, re-derived over all 180 logs:

```
## Infrastructure a run survived (#2810)

4 retry attempt(s) across 2 run(s) failed for a reason the run then recovered
from. These are NOT causes of death and appear in no cause row: a run can
spend its whole allowance here, continue, and die later of something else.

- `infra.drafter_unreachable` -- 4 attempt(s)
    - run-issue384-102849: attempt 1/3 -- drafter call failed: All credentials failed via agy
    - run-issue41-184913: attempt 1/3 -- ...
    - run-issue41-184913: attempt 2/3 -- ...
    - run-issue41-184913: attempt 3/3 -- ...
```

The 3/3 is the point. Anyone sizing that cap was reading a number that omitted its most expensive customer.

## Its own section, not a cause row

This is the binding constraint the issue set, and it is why the section is separate: **these runs did not die of this.** Putting a non-death in the deaths table would move a distribution nobody decided to move.

Re-derived over all 180 logs, every cause count is byte-identical — `budget 45, issue_body 34, model_output 26, unrecorded 15, infrastructure 11, upstream_artifact 4`, 135 classified, nothing unclassified. `test_survived_events_are_not_a_cause_and_have_no_row` asserts the new keys never acquire a `Cause` row, so a later change cannot quietly fold them in.

## The reason table is closed

`SURVIVED_EVENT_KINDS` is authored, one entry today. An unmatched reason counts as `survived.unclassified` and prints verbatim rather than folding into a neighbour — the same rule the cause table follows, and for the same reason: the first three deterministic-failure causes came to share one row by exactly that kind of absorption.

## Tests

`tests/unit/test_survived_infrastructure.py`, 10 tests: classification including the unmatched and empty cases, the index's grouping and ordering, a run that survived nothing contributing nothing, the whole-allowance case asserted explicitly, and the two structural guards above. `RunLogFacts.survived_events` defaults empty, so a log with no such line parses exactly as before.

Full unit suite: **10033 passed**. No ratchet number moves.
