### PR TITLE
fix: check that every node module supplies a node (Closes #2813)

### DIFF
--- a/assemblyzero/workflows/narration.py
+++ b/assemblyzero/workflows/narration.py
@@ -119,6 +119,20 @@ def narrated(node_id: str, fn, atlas: dict, total: int, stage: str = ""):
         return fn(state, *args, **kwargs)
 
     _wrapped.__name__ = getattr(fn, "__name__", node_id)
+    # #2813: carry enough identity for a node to name the module it came from.
+    # Without these two lines every node callable in every compiled graph
+    # reports `__module__ == "assemblyzero.workflows.narration"`, so nothing
+    # can ask which FILE supplies a node -- and that is the only question that
+    # catches a module which is imported but wired to nothing.
+    # `validate_commit_message` lived in exactly that gap: re-exported by
+    # `testing/nodes/__init__.py` and therefore "reachable", declared as a
+    # node by no graph, dead for six months (#2787).
+    #
+    # Assigned narrowly rather than with `functools.wraps`, which would also
+    # copy `__dict__` and `__qualname__`. This wrapper stands in front of
+    # every node in the fleet; the smaller edit is the safer one.
+    _wrapped.__module__ = getattr(fn, "__module__", _wrapped.__module__)
+    _wrapped.__wrapped__ = fn
     return _wrapped
 
 

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -127,6 +127,15 @@ def _wrap_with_checkpoint(node_fn: Callable[..., dict[str, Any]],
         except Exception as e:
             print(f"  [CP:{ckpt_name}] wrapper caught unexpected error: {e}")
         return result
+
+    # #2813: the same carry `narrated` performs, for the same reason. This
+    # wrapper stands between a node function and the graph for six nodes;
+    # without it they report their module as `graph`, and nothing can ask
+    # which file supplies a node -- the question that catches a module
+    # imported but wired to nothing (#2787).
+    wrapped.__name__ = getattr(node_fn, "__name__", "wrapped")
+    wrapped.__module__ = getattr(node_fn, "__module__", wrapped.__module__)
+    wrapped.__wrapped__ = node_fn
     return wrapped
 
 

--- a/tests/unit/test_node_modules_supply_nodes.py
+++ b/tests/unit/test_node_modules_supply_nodes.py
@@ -1,0 +1,196 @@
+"""Every module under a `nodes/` package must supply a node (#2813).
+
+#2791 asks whether a module is **imported** when the graphs are built.
+This asks whether any graph **declares a node from it**. The difference is
+not academic: a re-export satisfies the first and not the second, and
+`validate_commit_message.py` sat in that gap for six months -- imported by
+`testing/nodes/__init__.py`, therefore counted reachable, declared as a node
+by nothing, carrying two registry halt sites that could not fire. #2787
+found it by hand; this makes the question a check.
+
+Four instances of the same defect are on record: `run_tests.py` (#2753),
+`check_coverage.py` (#2791), `validate_commit_message.py` (#2787), and six
+modules across three packages (#2811). The first was found six months late.
+
+**How a node names its module.** Two wrappers stand between a node function
+and the graph -- `workflows/narration.py::narrated` for every node, and
+`testing/graph.py::_wrap_with_checkpoint` for six of them. Both set only
+`__name__` before #2813, so every node callable reported its module as the
+wrapper's. They now carry `__module__` and `__wrapped__`, which is what
+makes this check possible; `TestTheWrappersCarryIdentity` pins that, because
+if either stops carrying it this check silently starts passing everything.
+
+**Resolution is a chain, not one attribute.** LangGraph stores a node as a
+`RunnableCallable` and a compiled graph wraps it again, so `_modules_of`
+follows `func`, `_func`, `__wrapped__`, `bound`, `runnable` and `steps`.
+Measured: without that walk, 31 of 48 node modules read as orphans, nine of
+them live nodes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+BUILDERS = [
+    ("testing", "assemblyzero.workflows.testing.graph",
+     "build_testing_workflow"),
+    ("requirements", "assemblyzero.workflows.requirements.graph",
+     "create_requirements_graph"),
+    ("implementation_spec", "assemblyzero.workflows.implementation_spec.graph",
+     "create_implementation_spec_graph"),
+    ("orchestrator", "assemblyzero.workflows.orchestrator.graph",
+     "create_orchestration_graph"),
+]
+
+#: Modules under a `nodes/` package that supply no node. Closed and authored;
+#: an entry is a decision about one file and has to say what it is instead.
+#: Every one of these was checked by finding its importer, not assumed.
+SUPPLIES_NO_NODE_EXEMPTIONS: dict[str, str] = {
+    # A re-export shim. The node function lives in
+    # `implementation/orchestrator.py`, which DOES supply the node.
+    "implement_code": "re-export shim; the node is implementation/orchestrator",
+    # Helpers, each imported by a module that does supply a node.
+    "adversarial_validator": "helper imported by adversarial_node",
+    "adversarial_writer": "helper imported by adversarial_node",
+    "cleanup_helpers": "helper imported by the cleanup node",
+    "claude_client": "the implementation stage's model transport, not a node",
+    "context": "token/context helpers imported by implementation/orchestrator",
+    "routing": "model-selection helpers imported by implementation/orchestrator",
+    "prompts": "prompt builders imported by implementation/orchestrator",
+    "parsers": "response parsers imported by implementation/orchestrator",
+    "edit_script": "edit-block helpers imported by generate_spec",
+    "edit_script_fix": "edit-block repair helpers imported by generate_spec",
+    "lld_revision": "revision helpers imported by generate_draft",
+    "ponder_rules": "rule table imported by the ponder node",
+    "retry_prompt_builder": "retry prompts imported by generate_spec",
+    "deprecated": (
+        "batch-mode functions kept for backward compatibility (#272), "
+        "re-exported by implementation/__init__ and called by nothing in a "
+        "graph -- a retirement candidate, but its own decision"
+    ),
+    "import_validator": (
+        "lazily imported by parsers.py INSIDE a function, so it is live at "
+        "run time and invisible to any build-time inspection"
+    ),
+    "assembly_node": (
+        "the Librarian's entry point (#88): imported and exported by "
+        "workflows/lld/__init__.py and covered by test_document_assembler, "
+        "but the RAG augmentation was never given a graph. Dormant feature "
+        "rather than dead code -- see #2811"
+    ),
+}
+
+
+def _modules_of(obj, depth: int = 0) -> set[str]:
+    """Every `assemblyzero` module reachable down one node's callable chain."""
+    out: set[str] = set()
+    if obj is None or depth > 6:
+        return out
+    module = getattr(obj, "__module__", "") or ""
+    if module.startswith("assemblyzero."):
+        out.add(module.rsplit(".", 1)[-1])
+    for attr in ("func", "_func", "__wrapped__", "afunc", "bound", "runnable"):
+        out |= _modules_of(getattr(obj, attr, None), depth + 1)
+    steps = getattr(obj, "steps", None)
+    if isinstance(steps, (list, tuple)):
+        for step in steps:
+            out |= _modules_of(step, depth + 1)
+    return out
+
+
+def _modules_supplying_nodes() -> set[str]:
+    supplying: set[str] = set()
+    for _name, module, fn in BUILDERS:
+        graph = getattr(importlib.import_module(module), fn)()
+        nodes = getattr(graph, "nodes", None)
+        if nodes is None:
+            nodes = graph.get_graph().nodes
+        for node in nodes:
+            supplying |= _modules_of(nodes[node])
+    return supplying
+
+
+def _node_modules_on_disk() -> set[str]:
+    found: set[str] = set()
+    for path in (REPO_ROOT / "assemblyzero" / "workflows").rglob("*.py"):
+        parts = path.parts
+        if "nodes" not in parts or "__pycache__" in parts:
+            continue
+        if path.stem == "__init__":
+            continue
+        found.add(path.stem)
+    return found
+
+
+class TestTheWrappersCarryIdentity:
+    """The load-bearing lines. If either wrapper stops carrying `__module__`,
+    every node reports the wrapper and the check below passes everything --
+    silently, which is the worst way for a guard to die."""
+
+    def test_narrated_names_the_wrapped_module(self):
+        from assemblyzero.workflows.narration import narrated
+
+        def fake_node(state):
+            return {}
+
+        wrapped = narrated("N0_x", fake_node, {}, 1, "impl")
+        assert wrapped.__module__ == fake_node.__module__
+        assert wrapped.__wrapped__ is fake_node
+
+    def test_the_checkpoint_wrapper_names_the_wrapped_module(self):
+        from assemblyzero.workflows.testing.graph import _wrap_with_checkpoint
+
+        def fake_node(state):
+            return {}
+
+        wrapped = _wrap_with_checkpoint(fake_node, "post-x")
+        assert wrapped.__module__ == fake_node.__module__
+        assert wrapped.__wrapped__ is fake_node
+
+    def test_real_nodes_name_real_modules(self):
+        supplying = _modules_supplying_nodes()
+        assert "verify_phases" in supplying, sorted(supplying)
+        assert "scaffold_tests" in supplying, sorted(supplying)
+        assert "narration" not in supplying, (
+            "nodes are reporting the wrapper's module again"
+        )
+
+
+class TestEveryNodeModuleSuppliesANode:
+    def test_no_module_is_wired_to_nothing(self):
+        orphans = sorted(
+            _node_modules_on_disk()
+            - _modules_supplying_nodes()
+            - set(SUPPLIES_NO_NODE_EXEMPTIONS)
+        )
+        assert not orphans, (
+            "modules under a nodes/ package that no graph declares a node "
+            "from: " + ", ".join(orphans) + ". Wire it, retire it, or add it "
+            "to SUPPLIES_NO_NODE_EXEMPTIONS with what it is instead."
+        )
+
+    def test_it_would_have_caught_the_module_that_hid(self):
+        """Discrimination, on the real case rather than a synthetic one.
+
+        `validate_commit_message` was IMPORTED and supplied no node. #2791's
+        check passes that shape by construction; this one must fail it, or
+        it is only a second copy of #2791.
+        """
+        on_disk = _node_modules_on_disk() | {"validate_commit_message"}
+        orphans = (
+            on_disk
+            - _modules_supplying_nodes()
+            - set(SUPPLIES_NO_NODE_EXEMPTIONS)
+        )
+        assert orphans == {"validate_commit_message"}, sorted(orphans)
+
+    def test_every_exemption_names_a_real_file_and_says_what_it_is(self):
+        on_disk = _node_modules_on_disk()
+        for module, reason in SUPPLIES_NO_NODE_EXEMPTIONS.items():
+            assert module in on_disk, (
+                f"{module} is exempted but no longer on disk -- remove it"
+            )
+            assert len(reason.strip()) > 20, f"{module}: {reason!r}"


### PR DESCRIPTION
A module under a `nodes/` package must supply a node, not merely be imported.

Closes #2813

## The gap

The guard added in #2791 asks whether a module is **imported** when the graphs are built. That is satisfied by a re-export — which is how `validate_commit_message.py` counted as reachable for six months while no graph declared it as a node and the two registry halt sites it carried could not fire. #2787 found it by hand, by building every graph and enumerating node names. This makes that the check.

`check_coverage.py` was caught by #2791 only because it was imported nowhere at all. Had anyone added it to `nodes/__init__.py`'s re-export list — which is what that file is for — it would have been invisible to both guards.

## Two wrappers had to carry identity

`narrated` wraps every node; `testing/graph.py::_wrap_with_checkpoint` wraps six more. Both set only `__name__`, so every node callable in every graph reported the wrapper's module and nothing could ask which file supplies a node.

Both now carry `__module__` and `__wrapped__`, assigned narrowly rather than through `functools.wraps` — that would also copy `__dict__` and `__qualname__`, and these wrappers stand in front of every node in the fleet.

## Resolution is a chain, not one attribute

LangGraph stores a node as a `RunnableCallable` and a compiled graph wraps it again, so `_modules_of` follows `func`, `_func`, `__wrapped__`, `bound`, `runnable` and `steps`. The numbers, measured rather than assumed:

| | orphans |
|---|---|
| before any fix | 31 of 48 — nine of them **live nodes** |
| after `narrated` carries `__module__` | 28 |
| after `_wrap_with_checkpoint` too | 23 |
| after the chain walk, on merged main | **17** |

Every one of the 17 was checked by finding its importer, not assumed: fifteen helpers, one re-export shim (`implement_code` — the node lives in `implementation/orchestrator.py`), and `assembly_node`, the Librarian's dormant entry point (#88).

## It is proven to be more than a second copy of #2791

`test_it_would_have_caught_the_module_that_hid` feeds the check `validate_commit_message` — the module #2791's guard passes **by construction** — and requires this one to fail on it. A guard that only reproduces the weaker guard's result has not earned its place, and this is four instances into the same defect: `run_tests.py` (#2753), `check_coverage.py` (#2791), `validate_commit_message.py` (#2787), six modules across three packages (#2811).

## Tests

`tests/unit/test_node_modules_supply_nodes.py`, 6 tests. Both wrappers are asserted to carry the module and the wrapped function; real graph nodes are asserted to name real modules and *not* `narration`, so a silent regression in either wrapper fails here rather than turning the check into a no-op; the exemption table must name files that exist and say what each module is instead.

Full unit suite: **10039 passed**.
