### PR TITLE
fix: a replay never writes to GitHub — every push, PR and must-resolve filing is inert under one switch (Closes #2826)

### DIFF
--- a/assemblyzero/core/github_writes.py
+++ b/assemblyzero/core/github_writes.py
@@ -1,0 +1,145 @@
+"""One switch that makes every GitHub write inert (#2826).
+
+A replay runs the real graph against a throwaway clone whose ``origin`` is
+the real target repository. On 2026-09-04 a replay of a halted run reached
+the spec review's BLOCKED path and ``file_must_resolve`` wrote a real
+issue -- boostgauge #434, a copy of a question the operator had already
+ruled on and closed -- and the next authorised launch was refused by it.
+
+The graph has no single place where "this is a replay" is known, and the
+writes are scattered: ``git push`` in four modules, ``gh pr create`` in two,
+``gh pr merge``, ``gh issue create`` and ``gh issue comment``. Guarding each
+site is a list that drifts. Guarding the two process runners everything
+funnels through -- ``assemblyzero.utils.shell.run_command`` and the
+must-resolve filer's runner -- is one predicate, and a site added tomorrow
+is covered the day it is written.
+
+The switch is an environment variable so it crosses every boundary the
+graph does (nodes, helper modules, the provider) without threading a flag
+through state. It is set only by ``inert_github_writes(...)``, which
+restores the previous value on exit, and never by a live roll.
+
+What counts as a write is a closed set, listed in ``_WRITE_VERBS``: every
+entry is a command that changes something on GitHub. Reads (``gh pr view``,
+``gh issue list``, ``git fetch``) stay live, because a replay that cannot
+read the board would diverge from the recording for a reason that has
+nothing to do with the gate under test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from contextlib import contextmanager
+from typing import Iterator, Sequence
+
+#: The switch. Empty (or unset) means live; any other value is the reason
+#: writes are inert, and it is printed on every suppressed write.
+INERT_ENV = "ASSEMBLYZERO_GITHUB_WRITES_INERT"
+
+#: What a suppressed write's stdout starts with, so a caller that echoes the
+#: "URL" it got back prints something a reader can recognise.
+SUPPRESSED_MARK = "(inert:"
+
+# Closed set. (program, first subcommand or None, second subcommand or None).
+# ``git push`` is a write whatever follows it. ``gh`` writes are named by
+# their verb; everything else under ``gh`` is a read.
+_WRITE_VERBS: frozenset[tuple[str, str | None, str | None]] = frozenset({
+    ("git", "push", None),
+    ("gh", "pr", "create"),
+    ("gh", "pr", "merge"),
+    ("gh", "pr", "close"),
+    ("gh", "pr", "edit"),
+    ("gh", "pr", "comment"),
+    ("gh", "pr", "review"),
+    ("gh", "pr", "ready"),
+    ("gh", "issue", "create"),
+    ("gh", "issue", "comment"),
+    ("gh", "issue", "edit"),
+    ("gh", "issue", "close"),
+    ("gh", "issue", "reopen"),
+    ("gh", "label", "create"),
+    ("gh", "release", "create"),
+})
+
+
+def inert_reason() -> str:
+    """Why writes are inert, or "" when they are live."""
+    return os.environ.get(INERT_ENV, "").strip()
+
+
+@contextmanager
+def inert_github_writes(reason: str) -> Iterator[None]:
+    """Make every GitHub write inert for the duration, then restore.
+
+    ``reason`` is what a suppressed write prints and what the must-resolve
+    ledger records; "replay" is the one caller today.
+    """
+    if not reason.strip():
+        raise ValueError("inert_github_writes needs a reason; a blank one reads as live")
+    previous = os.environ.get(INERT_ENV)
+    os.environ[INERT_ENV] = reason.strip()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(INERT_ENV, None)
+        else:
+            os.environ[INERT_ENV] = previous
+
+
+def _words(args: Sequence[str] | str) -> list[str]:
+    if isinstance(args, str):
+        return args.split()
+    return [str(a) for a in args]
+
+
+def is_github_write(args: Sequence[str] | str) -> bool:
+    """Whether this argv would change something on GitHub.
+
+    ``git -C <path> push ...`` counts: global ``-C``/``-c`` options before the
+    verb are skipped so the verb is read wherever it sits.
+    """
+    words = _words(args)
+    if not words:
+        return False
+    program = os.path.basename(words[0]).lower()
+    if program.endswith(".exe"):
+        program = program[:-4]
+    rest = words[1:]
+    # Skip git's global options that take a value.
+    while program == "git" and len(rest) >= 2 and rest[0] in ("-C", "-c", "--git-dir", "--work-tree"):
+        rest = rest[2:]
+    first = rest[0] if rest else None
+    second = rest[1] if len(rest) > 1 else None
+    if (program, first, None) in _WRITE_VERBS:
+        return True
+    return (program, first, second) in _WRITE_VERBS
+
+
+def suppressed_result(args: Sequence[str] | str, reason: str) -> subprocess.CompletedProcess:
+    """What a suppressed write returns: success, with stdout that says so.
+
+    Callers read the URL of a created PR out of stdout. Under a replay that
+    URL is this string, which begins with ``SUPPRESSED_MARK`` so that a log
+    line or a report carrying it cannot be mistaken for a real URL.
+    """
+    words = _words(args)
+    return subprocess.CompletedProcess(
+        list(words), 0,
+        f"{SUPPRESSED_MARK}{reason}) {' '.join(words[:3])} not run",
+        "",
+    )
+
+
+def suppress_if_inert(
+    args: Sequence[str] | str, *, log=print
+) -> subprocess.CompletedProcess | None:
+    """The one call a runner makes: a fake success when the write is inert,
+    None when the command should run for real."""
+    reason = inert_reason()
+    if not reason or not is_github_write(args):
+        return None
+    words = _words(args)
+    log(f"    [{reason}] GitHub write suppressed: {' '.join(words[:4])}")
+    return suppressed_result(words, reason)

--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -45,6 +45,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from assemblyzero.core.github_writes import inert_reason, suppress_if_inert
+
 MUST_RESOLVE_LABEL = "must-resolve"
 RUN_TAG_ENV = "SPEEDRUN_RUN_TAG"
 RUN_START_ENV = "SPEEDRUN_RUN_START"
@@ -161,6 +163,12 @@ class FilingResult:
 
 
 def _default_runner(args: list[str]) -> subprocess.CompletedProcess:
+    # #2826: the filer's own runner honours the same switch as run_command,
+    # so even a caller that bypasses the explicit branch in file_must_resolve
+    # cannot write under a replay.
+    suppressed = suppress_if_inert(args)
+    if suppressed is not None:
+        return suppressed
     try:
         return subprocess.run(
             args, capture_output=True, text=True, encoding="utf-8", errors="replace"
@@ -419,6 +427,25 @@ def file_must_resolve(
         conflict.get("criterion_a", ""), conflict.get("criterion_b", "")
     )
 
+    # #2826: a replay never writes to GitHub. On 2026-09-04 a replay of a
+    # halted run reached this point and filed boostgauge #434 -- a copy of a
+    # question already ruled and closed -- and the next launch was refused by
+    # it. The suppressed filing is recorded in the ledger without a number so
+    # the replay report can still say "this run would have asked here", and
+    # the launcher's reader, which keys on the number, never counts it.
+    inert = inert_reason()
+    if inert:
+        log(
+            f"  [{origin.tag}] NOT FILED ({inert}): GitHub writes are inert. "
+            f"A live roll would have raised must-resolve fingerprint {fingerprint} "
+            f"against #{source_issue}."
+        )
+        record_suppressed(
+            repo_root, title=build_title(source_issue, conflict),
+            fingerprint=fingerprint, run_id=run_id, ts=conflict_ts, reason=inert,
+        )
+        return FilingResult(True, "suppressed", None, fingerprint, detail=inert)
+
     slug = repo_slug(repo_root, runner=runner)
     if not slug:
         log(f"  [{origin.tag}] could not file must-resolve: no GitHub remote for {repo_root}")
@@ -577,6 +604,38 @@ def record_filed(
     except OSError:
         # The roll is already halting. Losing the ledger line costs the
         # summary a number; raising here would cost the halt.
+        return False
+
+
+def record_suppressed(
+    repo_root: Path | str,
+    *,
+    title: str,
+    fingerprint: str | None = None,
+    run_id: str = "",
+    ts: str | None = None,
+    reason: str,
+) -> bool:
+    """Append one filing that was NOT made because writes were inert (#2826).
+
+    Same file, same append-only discipline, no number: ``read_filed`` keys on
+    the number and so never surfaces these to the launcher, while the line
+    itself keeps the record that a replay reached a question.
+    """
+    try:
+        path = filed_ledger_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "number": None,
+                "suppressed": reason,
+                "title": title or "",
+                "fingerprint": fingerprint or "",
+                "run_id": run_id or "",
+                "ts": ts or datetime.now().strftime(_TS_FMT),
+            }) + "\n")
+        return True
+    except OSError:
         return False
 
 

--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -440,9 +440,9 @@ def file_must_resolve(
             f"A live roll would have raised must-resolve fingerprint {fingerprint} "
             f"against #{source_issue}."
         )
-        record_suppressed(
-            repo_root, title=build_title(source_issue, conflict),
-            fingerprint=fingerprint, run_id=run_id, ts=conflict_ts, reason=inert,
+        record_filed(
+            repo_root, number=None, title=build_title(source_issue, conflict),
+            fingerprint=fingerprint, run_id=run_id, ts=conflict_ts, suppressed=inert,
         )
         return FilingResult(True, "suppressed", None, fingerprint, detail=inert)
 
@@ -581,61 +581,38 @@ def record_filed(
     fingerprint: str | None = None,
     run_id: str = "",
     ts: str | None = None,
+    suppressed: str = "",
 ) -> bool:
     """Append one filed question to the local ledger. Never raises.
 
     Append-only JSONL so two rolls writing at once cannot lose each other's
     line, and so a corrupt line costs one entry rather than the file.
+
+    ``suppressed`` (#2826) records a filing that was NOT made because GitHub
+    writes were inert -- a replay reaching a question. Such a line carries no
+    number, and ``read_filed`` keys on the number, so the launcher never
+    counts it while the record that the replay got there survives.
     """
-    if not number:
+    if not number and not suppressed:
         return False
+    row: dict = {
+        "number": int(number) if number else None,
+        "title": title or "",
+        "fingerprint": fingerprint or "",
+        "run_id": run_id or "",
+        "ts": ts or datetime.now().strftime(_TS_FMT),
+    }
+    if suppressed:
+        row["suppressed"] = suppressed
     try:
         path = filed_ledger_path(repo_root)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps({
-                "number": int(number),
-                "title": title or "",
-                "fingerprint": fingerprint or "",
-                "run_id": run_id or "",
-                "ts": ts or datetime.now().strftime(_TS_FMT),
-            }) + "\n")
+            fh.write(json.dumps(row) + "\n")
         return True
     except OSError:
         # The roll is already halting. Losing the ledger line costs the
         # summary a number; raising here would cost the halt.
-        return False
-
-
-def record_suppressed(
-    repo_root: Path | str,
-    *,
-    title: str,
-    fingerprint: str | None = None,
-    run_id: str = "",
-    ts: str | None = None,
-    reason: str,
-) -> bool:
-    """Append one filing that was NOT made because writes were inert (#2826).
-
-    Same file, same append-only discipline, no number: ``read_filed`` keys on
-    the number and so never surfaces these to the launcher, while the line
-    itself keeps the record that a replay reached a question.
-    """
-    try:
-        path = filed_ledger_path(repo_root)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps({
-                "number": None,
-                "suppressed": reason,
-                "title": title or "",
-                "fingerprint": fingerprint or "",
-                "run_id": run_id or "",
-                "ts": ts or datetime.now().strftime(_TS_FMT),
-            }) + "\n")
-        return True
-    except OSError:
         return False
 
 

--- a/assemblyzero/utils/shell.py
+++ b/assemblyzero/utils/shell.py
@@ -10,12 +10,12 @@ Issue #598: Permissible Command Middleware.
 Issue #611: Activate middleware across workflow nodes.
 """
 
-import re
 import sys
 import subprocess
 from typing import Any
 
 from assemblyzero.core.errors import SecurityException
+from assemblyzero.core.github_writes import suppress_if_inert
 
 PROHIBITED_FLAGS: frozenset[str] = frozenset({"--admin", "--force", "-D", "--hard"})
 
@@ -78,6 +78,13 @@ def run_command(
         SecurityException: If the command contains prohibited flags.
     """
     validate_command(command)
+
+    # #2826: under a replay every GitHub write is inert. Decided here, at the
+    # one runner every workflow node goes through, so a push or a PR added
+    # tomorrow is covered the day it is written.
+    suppressed = suppress_if_inert(command)
+    if suppressed is not None:
+        return suppressed
 
     if isinstance(command, str):
         command = wrap_bash_if_needed(command)

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
-    "files_scanned": 302,
-    "sites_examined": 8817,
+    "files_scanned": 303,
+    "sites_examined": 8840,
     "findings_total": 533
   },
   "undeclared": [

--- a/tests/unit/test_github_writes_inert.py
+++ b/tests/unit/test_github_writes_inert.py
@@ -1,0 +1,263 @@
+"""#2826: a replay never writes to GitHub.
+
+On 2026-09-04 a replay of a halted run reached the spec review's BLOCKED
+path and ``file_must_resolve`` wrote boostgauge #434 -- a copy of a question
+already ruled and closed -- from the throwaway clone, whose ``origin`` is the
+real repository. The next authorised launch was refused by it.
+
+These tests pin the one switch that makes every write inert, the two
+runners that honour it, the filer's explicit branch, and the replay runner's
+use of it. The control -- writes are live when the switch is off -- is here
+too, so the guard cannot be satisfied by a runner that never runs anything.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.github_writes import (
+    INERT_ENV,
+    SUPPRESSED_MARK,
+    inert_github_writes,
+    inert_reason,
+    is_github_write,
+    suppress_if_inert,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _live_by_default(monkeypatch):
+    monkeypatch.delenv(INERT_ENV, raising=False)
+
+
+class TestTheClosedSet:
+    @pytest.mark.parametrize("argv", [
+        ["git", "push"],
+        ["git", "push", "--set-upstream", "origin", "issue-4"],
+        ["git", "-C", "/some/repo", "push", "-u", "origin", "grave"],
+        ["gh", "pr", "create", "--title", "t", "--body", "b"],
+        ["gh", "pr", "merge", "https://github.com/o/r/pull/1", "--squash"],
+        ["gh", "issue", "create", "--repo", "o/r", "--title", "t"],
+        ["gh", "issue", "comment", "5", "--repo", "o/r", "--body", "x"],
+        ["gh", "label", "create", "must-resolve", "--repo", "o/r"],
+        "git push origin main",
+    ])
+    def test_writes_are_writes(self, argv):
+        assert is_github_write(argv)
+
+    @pytest.mark.parametrize("argv", [
+        ["git", "fetch", "origin"],
+        ["git", "status", "--porcelain"],
+        ["git", "-C", "/some/repo", "remote", "get-url", "origin"],
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        ["gh", "pr", "view", "https://github.com/o/r/pull/1", "--json", "state"],
+        ["gh", "issue", "list", "--repo", "o/r", "--label", "must-resolve"],
+        ["gh", "issue", "view", "4", "--json", "title,body"],
+        ["gh", "auth", "status"],
+        ["pytest", "-q"],
+        [],
+    ])
+    def test_reads_are_not(self, argv):
+        assert not is_github_write(argv)
+
+
+class TestTheSwitch:
+    def test_live_when_unset(self):
+        assert inert_reason() == ""
+        assert suppress_if_inert(["git", "push"]) is None
+
+    def test_context_sets_then_restores(self):
+        with inert_github_writes("replay"):
+            assert inert_reason() == "replay"
+            result = suppress_if_inert(["gh", "pr", "create"], log=lambda _: None)
+            assert result is not None
+            assert result.returncode == 0
+            assert result.stdout.startswith(SUPPRESSED_MARK)
+            assert "replay" in result.stdout
+        assert inert_reason() == ""
+
+    def test_restores_a_previous_value(self, monkeypatch):
+        monkeypatch.setenv(INERT_ENV, "outer")
+        with inert_github_writes("inner"):
+            assert inert_reason() == "inner"
+        assert inert_reason() == "outer"
+
+    def test_reads_still_run_under_inert(self):
+        with inert_github_writes("replay"):
+            assert suppress_if_inert(["gh", "issue", "list"], log=lambda _: None) is None
+
+    def test_blank_reason_is_refused(self):
+        with pytest.raises(ValueError):
+            with inert_github_writes("  "):
+                pass
+
+
+class TestRunCommand:
+    def test_a_write_is_not_spawned_under_inert(self, monkeypatch):
+        from assemblyzero.utils import shell
+
+        def never(*_args, **_kwargs):
+            raise AssertionError("subprocess.run was called for a GitHub write under inert")
+
+        monkeypatch.setattr(shell.subprocess, "run", never)
+        with inert_github_writes("replay"):
+            result = shell.run_command(["git", "push", "origin", "issue-4"])
+        assert result.returncode == 0
+        assert SUPPRESSED_MARK in result.stdout
+
+    def test_a_read_is_spawned_under_inert(self, monkeypatch):
+        from assemblyzero.utils import shell
+
+        seen: list[list[str]] = []
+
+        def fake_run(command, **_kwargs):
+            seen.append(list(command))
+            return subprocess.CompletedProcess(command, 0, "main\n", "")
+
+        monkeypatch.setattr(shell.subprocess, "run", fake_run)
+        with inert_github_writes("replay"):
+            result = shell.run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        assert result.stdout == "main\n"
+        assert seen == [["git", "rev-parse", "--abbrev-ref", "HEAD"]]
+
+    def test_a_write_is_spawned_when_live(self, monkeypatch):
+        """The control: with the switch off, a push reaches subprocess."""
+        from assemblyzero.utils import shell
+
+        seen: list[list[str]] = []
+
+        def fake_run(command, **_kwargs):
+            seen.append(list(command))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(shell.subprocess, "run", fake_run)
+        shell.run_command(["git", "push", "origin", "issue-4"])
+        assert seen == [["git", "push", "origin", "issue-4"]]
+
+
+def _conflict() -> dict:
+    return {
+        "criterion_a": "Live OS state",
+        "criterion_b": "Memory % exactly matches psutil.virtual_memory().percent",
+        "diverging_situation": "memory moves between the collector's read and the test's",
+    }
+
+
+def _live_runner(created_url: str = "https://github.com/o/r/issues/99\n"):
+    """A fake gh/git that answers the reads and records the writes."""
+    calls: list[list[str]] = []
+
+    def runner(args):
+        calls.append(list(args))
+        if args[:2] == ["git", "-C"] and "remote" in args:
+            return subprocess.CompletedProcess(args, 0, "https://github.com/o/r.git\n", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(args, 0, created_url, "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    return runner, calls
+
+
+class TestTheFiler:
+    def test_files_nothing_under_inert(self, tmp_path):
+        from assemblyzero.speedrun import must_resolve as mr
+
+        calls: list[list[str]] = []
+
+        def runner(args):
+            calls.append(list(args))
+            raise AssertionError(f"gh was invoked under inert: {args}")
+
+        with inert_github_writes("replay"):
+            result = mr.file_must_resolve(
+                tmp_path, 4, _conflict(), runner=runner, log=lambda _: None
+            )
+
+        assert result.ok
+        assert result.action == "suppressed"
+        assert result.issue_number is None
+        assert result.detail == "replay"
+        assert calls == []
+
+        rows = [
+            json.loads(line)
+            for line in mr.filed_ledger_path(tmp_path).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["suppressed"] == "replay"
+        assert rows[0]["number"] is None
+        assert rows[0]["fingerprint"] == result.fingerprint
+        # The launcher's reader keys on the number, so it never counts this.
+        assert mr.read_filed(tmp_path) == []
+
+    def test_still_files_when_live(self, tmp_path):
+        """The control: the same call with the switch off files the issue."""
+        from assemblyzero.speedrun import must_resolve as mr
+
+        runner, calls = _live_runner()
+        result = mr.file_must_resolve(
+            tmp_path, 4, _conflict(), runner=runner, log=lambda _: None
+        )
+        assert result.action == "filed"
+        assert result.issue_number == 99
+        assert any(c[:3] == ["gh", "issue", "create"] for c in calls)
+        assert [row["number"] for row in mr.read_filed(tmp_path)] == [99]
+
+    def test_the_filers_own_runner_honours_the_switch(self, monkeypatch):
+        from assemblyzero.speedrun import must_resolve as mr
+
+        def never(*_args, **_kwargs):
+            raise AssertionError("subprocess.run was called for a GitHub write under inert")
+
+        monkeypatch.setattr(mr.subprocess, "run", never)
+        with inert_github_writes("replay"):
+            result = mr._default_runner(["gh", "issue", "create", "--repo", "o/r"])
+        assert result.returncode == 0
+        assert SUPPRESSED_MARK in result.stdout
+
+
+def _load_replay_run():
+    path = ROOT / "tools" / "replay_run.py"
+    spec = importlib.util.spec_from_file_location("replay_run_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTheReplayRunner:
+    def test_main_collects_under_inert(self, tmp_path, monkeypatch, capsys):
+        replay_run = _load_replay_run()
+        observed: list[str] = []
+
+        def fake_collect(_args):
+            observed.append(inert_reason())
+            return [], ["nothing recorded"]
+
+        monkeypatch.setattr(replay_run, "collect", fake_collect)
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        rc = replay_run.main([
+            "--recording", str(tmp_path), "--clone", str(clone), "--issue", "4",
+        ])
+        assert observed == ["replay"]
+        assert inert_reason() == ""
+        assert rc == 0
+
+    def test_the_graph_is_streamed_under_inert(self):
+        """Pinned at the source: the stream loop sits inside the context, so a
+        caller of replay_spec_stage that bypasses main is covered too."""
+        source = (ROOT / "tools" / "replay_run.py").read_text(encoding="utf-8")
+        stream_at = source.index("for event in graph.stream(state, config):")
+        guard_at = source.rindex('with inert_github_writes("replay"):', 0, stream_at)
+        assert stream_at - guard_at < 400, "the inert guard must sit directly above the stream loop"

--- a/tools/replay_run.py
+++ b/tools/replay_run.py
@@ -36,6 +36,7 @@ from assemblyzero.core.utf8_console import install as _install_utf8_console  # n
 
 _install_utf8_console()
 
+from assemblyzero.core.github_writes import inert_github_writes  # noqa: E402
 from assemblyzero.core.scripted_provider import (  # noqa: E402
     ScriptedProvider,
     set_active,
@@ -219,11 +220,15 @@ def replay_spec_stage(
     try:
         graph = create_implementation_spec_graph()
         config = {"recursion_limit": recursion_limit(max_iterations)}
-        for event in graph.stream(state, config):
-            for node_name, node_output in event.items():
-                if node_name == "__end__" or not node_output:
-                    continue
-                final.update(node_output)
+        # #2826: the clone's origin is the real repository. Every GitHub
+        # write the graph can make -- a must-resolve issue, a push, a PR --
+        # is inert for the duration of the replay, and says so in the log.
+        with inert_github_writes("replay"):
+            for event in graph.stream(state, config):
+                for node_name, node_output in event.items():
+                    if node_name == "__end__" or not node_output:
+                        continue
+                    final.update(node_output)
     except Exception as exc:  # noqa: BLE001
         # Loud, not swallowed: the replay reports the exception as its outcome
         # rather than continuing with a state that never finished. A silent
@@ -355,7 +360,10 @@ def main(argv: list[str] | None = None) -> int:
             f"checkout is never the right base for a replay."
         )
 
-    results, skipped = collect(args)
+    # #2826: belt and braces -- the whole collection runs inert, so a write
+    # made outside the graph (a future stage, a helper) is covered too.
+    with inert_github_writes("replay"):
+        results, skipped = collect(args)
     if not results and not skipped:
         print("No recorded runs matched.")
         return 1


### PR DESCRIPTION
Closes #2826

## A replay wrote a real issue, and it blocked the next launch

A replay runs the real graph against a throwaway clone whose `origin` is the real target repository. On 2026-09-04 a replay of run 12 reached the spec review's BLOCKED path and `file_must_resolve` wrote boostgauge #434 from the clone — a copy of a question the operator had already ruled on — twice. Tonight's first authorised launch since run 12 was refused by it: `BLOCKED: this repository has 1 unanswered question ... #434`. The payload is the clone's own ledger (`data/replay/boostgauge/data/speedrun/filed-questions.jsonl`, two lines, `run_id: unknown`); the target repository's ledger ends at #433.

## One switch, at the two runners everything goes through

`assemblyzero/core/github_writes.py` — an environment variable set only by `inert_github_writes(reason)`, which restores the previous value on exit. `is_github_write(argv)` is a closed set: `git push` (with `-C`/`-c` globals skipped), `gh pr create|merge|close|edit|comment|review|ready`, `gh issue create|comment|edit|close|reopen`, `gh label create`, `gh release create`. Reads (`gh pr view`, `gh issue list`, `git fetch`) stay live, so a replay that could not read the board would not diverge for a reason unrelated to the gate under test.

Honoured at the seams rather than at the sites, so a push or a PR added tomorrow is covered the day it is written:

- `assemblyzero/utils/shell.py::run_command` — every workflow node's runner. A suppressed write returns success with stdout beginning `(inert:replay)`, so a caller that echoes the "URL" prints something a reader recognises.
- `assemblyzero/speedrun/must_resolve.py::_default_runner` — the filer's runner, same rule.
- `file_must_resolve` also takes an explicit branch before any `gh` call: logs `NOT FILED (replay)` with the fingerprint, writes a ledger line with `number: null, suppressed: replay` via the new `record_suppressed`, and returns `FilingResult(True, "suppressed")`. `read_filed` keys on the number, so the launcher never counts it, while the record that a replay reached a question survives.
- `tools/replay_run.py` — the graph stream loop runs inside `inert_github_writes("replay")`, and `main` wraps `collect` in it as well.

## Tests

`tests/unit/test_github_writes_inert.py`, 30 tests: the closed set (nine writes, ten reads); the switch sets, restores a previous value, refuses a blank reason, and leaves reads live; `run_command` does not spawn a write under inert and does spawn a read; the filer writes nothing under inert and the ledger line is ignored by the launcher's reader; the filer's own runner honours the switch; `replay_run.main` collects under inert; the guard sits directly above the stream loop. **The control is in each group** — with the switch off, `run_command` spawns the push and `file_must_resolve` files the issue — so the guard cannot be satisfied by a runner that never runs anything.

Neighbouring suites (must-resolve filing, the ledger, git operations, shell, replay, stages): 631 passed. Ruff clean on every changed file; the pre-existing unused `re` import in `shell.py` is removed.

## Not changed

The dedup rule — a fresh filing when an earlier question with the same fingerprint is already closed — is right for a live roll and stays. The clone under `data/replay/` and boostgauge #434 (closed as a duplicate, with the attribution) are as they were.
