### PR TITLE
fix: the requirements gate reads a verdict wherever the model put it — run 13's three answers now parse (Closes #2830)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -235,24 +235,113 @@ def _format_conflict_message(
     return "\n".join(lines)
 
 
-def _parse_analysis(raw: str) -> dict | None:
-    """Parse the analysis JSON, tolerating fenced or prefixed output."""
-    if not raw:
-        return None
-    text = raw.strip()
+#: #2830: where a model puts its findings when it ignores the schema. Run 13
+#: on boostgauge #4 answered three times -- `{"issues": [...]}`, a bare list,
+#: `{"issues": [...]}` again with different item keys -- and the gate threw all
+#: three away for want of the key `is_consistent`. The question the gate asks
+#: is "two quoted criteria and where they diverge"; every answer carried it.
+#: A closed set, authored from the recorded responses, not discovered.
+_FINDINGS_KEYS = ("conflicts", "issues", "findings", "contradictions", "problems")
+_CRITERION_A_KEYS = ("criterion_a", "quote_1", "quote_a", "first")
+_CRITERION_B_KEYS = ("criterion_b", "quote_2", "quote_b", "second")
+_SITUATION_KEYS = (
+    "diverging_situation", "divergence", "explanation", "description",
+    "situation", "reason",
+)
+_CATEGORY_KEYS = ("category", "type")
+
+
+def _strip_fence(text: str) -> str:
+    text = text.strip()
     if text.startswith("```"):
         first_newline = text.find("\n")
         if first_newline != -1:
             text = text[first_newline + 1 :]
         if text.rstrip().endswith("```"):
             text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def _first_str(item: dict, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _findings_of(parsed: Any) -> list | None:
+    """The list of findings, wherever the model put it; None when there is none."""
+    if isinstance(parsed, list):
+        return parsed
+    if isinstance(parsed, dict):
+        for key in _FINDINGS_KEYS:
+            value = parsed.get(key)
+            if isinstance(value, list):
+                return value
+        if "is_consistent" in parsed:
+            return []
+    return None
+
+
+def _normalise_finding(item: dict) -> dict:
+    """One finding in the canonical keys, keeping everything else the model said."""
+    out = dict(item)
+    a = _first_str(item, _CRITERION_A_KEYS)
+    b = _first_str(item, _CRITERION_B_KEYS)
+    quotes = item.get("quotes")
+    if isinstance(quotes, list):
+        strs = [q.strip() for q in quotes if isinstance(q, str) and q.strip()]
+        if not a and strs:
+            a = strs[0]
+        if not b and len(strs) >= 2:
+            b = strs[1]
+    out["criterion_a"] = a
+    out["criterion_b"] = b
+    out["diverging_situation"] = _first_str(item, _SITUATION_KEYS)
+    category = _first_str(item, _CATEGORY_KEYS)
+    if category:
+        out["category"] = category
+    return out
+
+
+def _parse_analysis(raw: str) -> dict | None:
+    """Parse the analysis JSON, tolerating fenced or prefixed output and, since
+    #2830, a response that carries the findings under another key or at the
+    root, with the two criteria and the diverging situation under other names.
+
+    The result is always canonical: ``conflicts`` holds every finding that
+    quotes two criteria; ``notes`` holds the rest (an undefined term, a
+    non-discriminating test), which are for the operator to read and are never
+    filed; ``is_consistent`` is the model's when it said so and "no conflict"
+    otherwise. None only when there is no findings list anywhere -- the gate
+    does not invent a verdict.
+    """
+    if not raw:
+        return None
     try:
-        parsed = json.loads(text.strip())
+        parsed = json.loads(_strip_fence(raw))
     except ValueError:
         return None
-    if not isinstance(parsed, dict) or "is_consistent" not in parsed:
+    findings = _findings_of(parsed)
+    if findings is None:
         return None
-    return parsed
+    conflicts: list[dict] = []
+    notes: list[dict] = []
+    for item in findings:
+        if not isinstance(item, dict):
+            continue
+        finding = _normalise_finding(item)
+        if finding["criterion_a"] and finding["criterion_b"]:
+            conflicts.append(finding)
+        else:
+            notes.append(finding)
+    out: dict = dict(parsed) if isinstance(parsed, dict) else {}
+    out["conflicts"] = conflicts
+    out["notes"] = notes
+    if not isinstance(out.get("is_consistent"), bool):
+        out["is_consistent"] = not conflicts
+    return out
 
 
 def _is_timeout(result: Any) -> bool:
@@ -499,6 +588,12 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
             return _halt_unverified(state, answered_by, reason)
 
     conflicts = parsed.get("conflicts") or []
+    # #2830: a finding that quotes fewer than two criteria is not a conflict
+    # and is never filed; it is still worth the operator's eye.
+    for note in parsed.get("notes") or []:
+        label = note.get("category") or "note"
+        text = note.get("diverging_situation") or note.get("term") or ""
+        print(f"  [N0c] noted, not a conflict ({label}): {text[:240]}")
     if parsed.get("is_consistent", True) or not conflicts:
         # CLEAN_MARKER is asserted verbatim by the pre-check's tests, so the
         # drafter goes on its own line rather than into that sentence.

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8840,
+    "sites_examined": 8860,
     "findings_total": 533
   },
   "undeclared": [

--- a/tests/fixtures/requirements_gate_shapes/run13-call1-fenced-issues-quote_1.txt
+++ b/tests/fixtures/requirements_gate_shapes/run13-call1-fenced-issues-quote_1.txt
@@ -1,0 +1,22 @@
+```json
+{
+  "issues": [
+    {
+      "category": "CONFLICTING CRITERIA",
+      "quote_1": "Collector returns accurate memory %, process count, handle count — process count equals psutil's row count ±1; handle count within 1 % of psutil's `num_handles` sum. Measured the same way as the ConPTY count: up to three back-to-back pairs",
+      "quote_2": "Memory % is the one direct `psutil.virtual_memory().percent` read taken on the tick; it is not cross-checked against a second live read and carries no tolerance, because there is no second reading to compare — a test asserts the field is that call's value on a mocked or injected `virtual_memory()`",
+      "divergence": "These statements specify mutually exclusive test implementations for the Memory % metric within the exact same acceptance criterion. Quote 1 groups Memory % with process and handle counts, requiring a live integration test that takes 'up to three back-to-back pairs' against live OS state. Quote 2 explicitly forbids a live cross-check and dictates a unit test against a mocked `virtual_memory()`. A developer must guess which test strategy to build, and choosing the live cross-check will result in flaky failures (as noted in ruling #433), wasting the run."
+    },
+    {
+      "category": "UNDEFINED OR MULTIPLY-DEFINED TERMS",
+      "term": "Python interpreter",
+      "description": "The requirements dictate counting rows whose 'process name is a Python interpreter', but never define the concrete set of process names this entails. It is ambiguous whether this strictly means 'python.exe', or should also include 'pythonw.exe', 'python3.exe', 'py.exe', etc. Guessing the wrong set of executable names will cause valid sessions to be missed or the wrong processes to be counted."
+    },
+    {
+      "category": "NON-DISCRIMINATING TESTS",
+      "test_case": "Unleashed session detection works: a row counts only when its process name ... is a Python interpreter AND its cmdline ... matches the unleashed-c-*.py signature",
+      "description": "Because the target set of 'Python interpreter' process names is undefined, a test case that simply asserts a mocked 'python.exe' row is counted will pass under all plausible readings (since everyone agrees 'python.exe' is an interpreter). The test fails to discriminate or reveal whether the implementation correctly supports other intended interpreter names (like 'pythonw.exe'), leaving the ambiguity unresolved."
+    }
+  ]
+}
+```

--- a/tests/fixtures/requirements_gate_shapes/run13-call2-bare-list-quotes.txt
+++ b/tests/fixtures/requirements_gate_shapes/run13-call2-bare-list-quotes.txt
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "CONFLICTING CRITERIA",
+    "quotes": [
+      "< 1% CPU overhead at 2s polling interval",
+      "the sweep's mean process_time over 8 ticks is < 20 ms"
+    ],
+    "explanation": "The requirement demands the CPU overhead of the entire 2-second polling interval be under 1% (< 20 ms per tick). However, the benchmark test intended to assert this explicitly measures only 'the sweep\\'s mean process_time'. The Implementation section strictly defines 'the sweep' as solely the NtQuerySystemInformation call, explicitly excluding the psutil calls for memory and per-row cmdline ('It is a dependency, not the sweep'). These statements specify different outcomes for an implementation where the sweep takes 2 ms but the psutil cmdline reads take 50 ms: the requirement dictates it fails the < 1% overhead limit, but the prescribed test dictates it passes."
+  }
+]

--- a/tests/fixtures/requirements_gate_shapes/run13-call3-fenced-issues-quotes.txt
+++ b/tests/fixtures/requirements_gate_shapes/run13-call3-fenced-issues-quotes.txt
@@ -1,0 +1,14 @@
+```json
+{
+  "issues": [
+    {
+      "type": "CONFLICTING CRITERIA",
+      "description": "The acceptance criterion defines a CPU overhead limit for the overall collector polling interval, but its mandated benchmark test measures only the CPU time of 'the sweep'. Because the text explicitly defines 'the sweep' as excluding the psutil dependency (which is used on every tick for memory and per-row command line reads), the requirement and the test diverge. If the NtQuerySystemInformation sweep takes 2 ms but the psutil reads take 40 ms, the benchmark test will pass (sweep < 20 ms) while the actual collector overhead is > 2%, failing the < 1% requirement.",
+      "quotes": [
+        "< 1% CPU overhead at 2s polling interval — asserted by a benchmark test: the sweep's mean process_time over 8 ticks is < 20 ms",
+        "The sweep is one NtQuerySystemInformation(SystemProcessInformation) call via ctypes... psutil remains for virtual_memory() and for the per-row cmdline of Python interpreter rows. It is a dependency, not the sweep."
+      ]
+    }
+  ]
+}
+```

--- a/tests/unit/test_requirements_conflict.py
+++ b/tests/unit/test_requirements_conflict.py
@@ -114,7 +114,8 @@ class TestN0cGate:
 
     def test_fenced_json_is_tolerated(self):
         parsed = _parse_analysis(f"```json\n{CONSISTENT_JSON}\n```")
-        assert parsed == {"is_consistent": True, "conflicts": []}
+        # #2830: the parser always returns the canonical shape, notes included.
+        assert parsed == {"is_consistent": True, "conflicts": [], "notes": []}
 
     def test_route_halts_on_error_message(self):
         assert (

--- a/tests/unit/test_requirements_gate_accepts_shapes.py
+++ b/tests/unit/test_requirements_gate_accepts_shapes.py
@@ -1,0 +1,135 @@
+"""#2830: the requirements gate reads a verdict wherever the model put it.
+
+Run 13 on boostgauge #4 (`run-issue4-014806`, 2026-09-05) asked the gate's
+question three times and got three well-formed JSON answers naming real
+contradictions, each in a shape the parser refused: `{"issues": [...]}` with
+`quote_1`/`quote_2`/`divergence`; a bare list with `quotes`/`explanation`;
+`{"issues": [...]}` with `quotes`/`description`. The run paid 1,327 s for no
+verdict. The three responses are the fixtures here, byte for byte, from the
+run's call recording.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun.must_resolve import unanswerable_reason
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+    _parse_analysis,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "requirements_gate_shapes"
+RECORDED = sorted(FIXTURES.glob("run13-*.txt"))
+
+
+class TestTheRecordedShapes:
+    def test_three_recordings_are_present(self):
+        assert [p.name for p in RECORDED] == [
+            "run13-call1-fenced-issues-quote_1.txt",
+            "run13-call2-bare-list-quotes.txt",
+            "run13-call3-fenced-issues-quotes.txt",
+        ]
+
+    @pytest.mark.parametrize("path", RECORDED, ids=[p.stem for p in RECORDED])
+    def test_each_recording_yields_one_conflict_the_filer_can_ask(self, path):
+        parsed = _parse_analysis(path.read_text(encoding="utf-8"))
+        assert parsed is not None, "the gate threw this answer away on 2026-09-05"
+        assert parsed["is_consistent"] is False
+        assert len(parsed["conflicts"]) == 1
+        conflict = parsed["conflicts"][0]
+        assert conflict["criterion_a"]
+        assert conflict["criterion_b"]
+        assert conflict["diverging_situation"]
+        assert conflict["criterion_a"] != conflict["criterion_b"]
+        # The filer's own contract (#2462): a conflict it can put to the operator.
+        assert unanswerable_reason(conflict) is None
+
+    def test_the_first_recording_carries_two_notes_that_are_not_conflicts(self):
+        parsed = _parse_analysis(RECORDED[0].read_text(encoding="utf-8"))
+        assert parsed is not None
+        categories = [n["category"] for n in parsed["notes"]]
+        assert categories == [
+            "UNDEFINED OR MULTIPLY-DEFINED TERMS",
+            "NON-DISCRIMINATING TESTS",
+        ]
+        for note in parsed["notes"]:
+            assert not (note["criterion_a"] and note["criterion_b"])
+
+    def test_the_first_recording_names_the_memory_criterion(self):
+        parsed = _parse_analysis(RECORDED[0].read_text(encoding="utf-8"))
+        assert parsed is not None
+        conflict = parsed["conflicts"][0]
+        assert "memory %" in conflict["criterion_a"].lower()
+        assert "virtual_memory" in conflict["criterion_b"]
+
+    def test_the_second_and_third_name_the_sweep_versus_the_tick(self):
+        for path in RECORDED[1:]:
+            parsed = _parse_analysis(path.read_text(encoding="utf-8"))
+            assert parsed is not None
+            conflict = parsed["conflicts"][0]
+            assert "1% CPU" in conflict["criterion_a"]
+            assert "sweep" in conflict["criterion_b"] or "sweep" in conflict["criterion_a"]
+
+
+class TestTheCanonicalShapeIsUnchanged:
+    def test_clean(self):
+        parsed = _parse_analysis(json.dumps({"is_consistent": True, "conflicts": []}))
+        assert parsed == {"is_consistent": True, "conflicts": [], "notes": []}
+
+    def test_one_conflict(self):
+        conflict = {
+            "criterion_a": "floor = highest value still in the window",
+            "criterion_b": "floor drifts toward the most recent value",
+            "diverging_situation": "when the window maximum is not the latest sample",
+        }
+        parsed = _parse_analysis(json.dumps({"is_consistent": False, "conflicts": [conflict]}))
+        assert parsed is not None
+        assert parsed["is_consistent"] is False
+        assert parsed["conflicts"] == [conflict]
+        assert parsed["notes"] == []
+
+    def test_fenced_canonical(self):
+        text = "```json\n" + json.dumps({"is_consistent": True, "conflicts": []}) + "\n```"
+        parsed = _parse_analysis(text)
+        assert parsed is not None
+        assert parsed["is_consistent"] is True
+
+    def test_the_models_own_is_consistent_wins_over_the_derived_one(self):
+        # It said inconsistent and listed nothing usable: the consumer already
+        # treats "no conflicts" as clean, so the flag is kept as stated and the
+        # consumer decides -- exactly as before #2830.
+        parsed = _parse_analysis(json.dumps({"is_consistent": False, "conflicts": []}))
+        assert parsed is not None
+        assert parsed["is_consistent"] is False
+        assert parsed["conflicts"] == []
+
+
+class TestNoVerdictIsStillNoVerdict:
+    @pytest.mark.parametrize("raw", [
+        "",
+        "not json at all",
+        json.dumps({"verdict": "fine"}),
+        json.dumps({"conflicts": "none"}),
+        json.dumps(42),
+    ])
+    def test_nothing_to_read_is_none(self, raw):
+        assert _parse_analysis(raw) is None
+
+    def test_an_empty_list_is_a_clean_verdict(self):
+        parsed = _parse_analysis("[]")
+        assert parsed is not None
+        assert parsed["is_consistent"] is True
+        assert parsed["conflicts"] == []
+
+    def test_a_finding_with_one_quote_is_a_note_not_a_conflict(self):
+        parsed = _parse_analysis(json.dumps({
+            "issues": [{"type": "CONFLICTING CRITERIA", "quotes": ["only one"],
+                        "explanation": "half an answer"}],
+        }))
+        assert parsed is not None
+        assert parsed["conflicts"] == []
+        assert len(parsed["notes"]) == 1
+        assert parsed["is_consistent"] is True


### PR DESCRIPTION
Closes #2830

## Three structured answers in 22 minutes, zero verdicts

Run 13 on boostgauge #4 (`run-issue4-014806`, 2026-09-05) halted in the requirements consistency gate with `REQUIREMENTS UNVERIFIED: the consistency gate did not run`. It ran three times — 271 s, 573 s, and a third call — and Gemini answered every time with well-formed JSON naming real contradictions. `_parse_analysis` returned `None` on all three for want of the key `is_consistent`, so the #2474 loop slept 60 s and 180 s and asked the same question again. The schema was in the prompt (#1843); the model ignored it three different ways.

The three responses, byte for byte from the run's call recording, are the fixtures: a fenced `{"issues": [{"category", "quote_1", "quote_2", "divergence"}, …]}`; a bare `[{"type", "quotes": [a, b], "explanation"}]`; a fenced `{"issues": [{"type", "description", "quotes": [a, b]}]}`.

## The parser reads the verdict wherever the model put it

`_parse_analysis` now: finds the list of findings at the root or under `conflicts` / `issues` / `findings` / `contradictions` / `problems`; reads the two criteria from `criterion_a`/`criterion_b`, `quote_1`/`quote_2`, `quote_a`/`quote_b`, or `quotes[0]`/`quotes[1]`; the diverging situation from `diverging_situation`, `divergence`, `explanation`, `description`, `situation`, `reason`; keeps `is_consistent` when the model stated it and derives "no conflict" otherwise. A finding with fewer than two quotes is a **note** — an undefined term, a non-discriminating test — printed for the operator and never filed. The result is always the canonical shape; the consumer is unchanged except for printing the notes. `None` only when there is no findings list anywhere: the gate still invents no verdict.

The key lists are closed and authored from the recorded responses.

## Tests

`tests/unit/test_requirements_gate_accepts_shapes.py`, 17 tests: each recording yields one conflict with both criteria and a diverging situation that the filer's own contract (#2462) accepts; the first also yields the two notes in order; the first names the memory criterion and the other two name the sweep-versus-tick; the canonical shape, fenced canonical, and a stated `is_consistent` are unchanged; nothing to read is still `None`; an empty list is a clean verdict; a one-quote finding is a note. `test_requirements_conflict.py`'s fenced-JSON expectation gains the `notes` key. Ruff clean.

## What it would have meant tonight

Run 13 would have halted at 271 s with a must-resolve naming the memory-criterion contradiction and the sweep-versus-tick contradiction — both real, both since fixed in boostgauge #4's body — instead of at 1,327 s with nothing.
