### PR TITLE
fix: a stop ends the scheduled task only when it is this repo's roll, never by name alone (Closes #2831)

### DIFF
--- a/tests/unit/test_kill_ends_only_its_own_task.py
+++ b/tests/unit/test_kill_ends_only_its_own_task.py
@@ -1,0 +1,162 @@
+"""#2831: a stop ends the scheduled task only when the task is this repo's roll.
+
+The task name is machine-global -- one AZ-SpeedrunRoll -- so `schtasks /End`
+by name ends whatever roll is live. On 2026-09-05 a unit test killing its own
+tmp roll ended the operator's live run 13 that way (Task Scheduler: Last
+Result 267014, "terminated by the user"), which is the #2510 wrapper death.
+The tool now reads the task's own command line and ends it only when that
+names the repository the stop was asked about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT / "tools") not in sys.path:
+    sys.path.insert(0, str(ROOT / "tools"))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+class _Scheduler:
+    """Stands in for _run: answers the verbose query, records every End."""
+
+    def __init__(self, task_repo: str | None, query_ok: bool = True):
+        self.task_repo = task_repo
+        self.query_ok = query_ok
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, cwd=None):
+        self.calls.append(list(cmd))
+        if cmd[:2] == ["schtasks", "/Query"]:
+            if not self.query_ok:
+                return subprocess.CompletedProcess(cmd, 1, "", "ERROR: cannot query")
+            body = ""
+            if self.task_repo:
+                body = (
+                    "TaskName:      \\AZ-SpeedrunRoll\n"
+                    f"Task To Run:   pythonw.exe speedrun_roll.py --repo {self.task_repo} "
+                    "--issue 4 --log-dir x\n"
+                )
+            return subprocess.CompletedProcess(cmd, 0, body, "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    def ends(self) -> list[list[str]]:
+        return [c for c in self.calls if c[:2] == ["schtasks", "/End"]]
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / "data" / "speedrun" / "runs").mkdir(parents=True)
+    return r
+
+
+@pytest.fixture
+def log_dir(repo):
+    return repo / "data" / "speedrun" / "runs"
+
+
+class TestTheQuestion:
+    def test_the_task_that_names_this_repo_is_ours(self, repo):
+        sched = _Scheduler(task_repo=str(repo))
+        with patch.object(sr, "_run", sched):
+            assert sr._task_names_repo(repo) is True
+
+    def test_a_task_that_names_another_repo_is_not(self, repo, tmp_path):
+        other = tmp_path / "somewhere-else"
+        sched = _Scheduler(task_repo=str(other))
+        with patch.object(sr, "_run", sched):
+            assert sr._task_names_repo(repo) is False
+
+    def test_forward_and_back_slashes_are_the_same_path(self, repo):
+        sched = _Scheduler(task_repo=str(repo).replace("\\", "/"))
+        with patch.object(sr, "_run", sched):
+            assert sr._task_names_repo(repo) is True
+
+    def test_a_scheduler_that_cannot_say_is_unknown(self, repo):
+        sched = _Scheduler(task_repo=str(repo), query_ok=False)
+        with patch.object(sr, "_run", sched):
+            assert sr._task_names_repo(repo) is None
+
+    def test_a_query_with_no_task_to_run_line_is_unknown(self, repo):
+        sched = _Scheduler(task_repo=None)
+        with patch.object(sr, "_run", sched):
+            assert sr._task_names_repo(repo) is None
+
+
+class TestKillRoll:
+    """The 2026-09-05 shape: a kill against a tmp repo while the live roll is
+    another repository's. Nothing is ended."""
+
+    def _kill(self, repo, log_dir, sched):
+        with patch.object(sr, "_run", sched), \
+                patch.object(sr.sys, "platform", "win32"), \
+                patch.object(sr, "is_live_python", lambda pid: False):
+            return sr.kill_roll(repo, log_dir, 1)
+
+    def test_another_repos_task_is_left_running(self, repo, log_dir, tmp_path, capsys):
+        live = tmp_path / "the-operators-live-roll"
+        sched = _Scheduler(task_repo=str(live))
+        assert self._kill(repo, log_dir, sched) == 0
+        assert sched.ends() == [], sched.calls
+        assert "another repository" in capsys.readouterr().out
+
+    def test_our_own_task_is_ended(self, repo, log_dir, sched=None):
+        sched = _Scheduler(task_repo=str(repo))
+        assert self._kill(repo, log_dir, sched) == 0
+        assert len(sched.ends()) == 1, sched.calls
+
+    def test_an_unqueryable_scheduler_ends_nothing_and_says_so(self, repo, log_dir, capsys):
+        sched = _Scheduler(task_repo=str(repo), query_ok=False)
+        assert self._kill(repo, log_dir, sched) == 0
+        assert sched.ends() == []
+        assert "could not say" in capsys.readouterr().out
+
+
+class TestStopDetached:
+    def _stop(self, repo, log_dir, sched):
+        with patch.object(sr, "_run", sched), \
+                patch.object(sr.sys, "platform", "win32"), \
+                patch.object(sr, "is_live_python", lambda pid: False):
+            return sr.stop_detached(log_dir, repo_root=repo)
+
+    def test_another_repos_task_is_left_running(self, repo, log_dir, tmp_path):
+        sched = _Scheduler(task_repo=str(tmp_path / "live"))
+        assert self._stop(repo, log_dir, sched) == 0
+        assert sched.ends() == [], sched.calls
+
+    def test_our_own_task_is_ended(self, repo, log_dir):
+        sched = _Scheduler(task_repo=str(repo))
+        assert self._stop(repo, log_dir, sched) == 0
+        assert len(sched.ends()) == 1, sched.calls
+
+    def test_the_repo_is_derived_from_the_log_dir_when_not_given(self, repo, log_dir):
+        sched = _Scheduler(task_repo=str(repo))
+        with patch.object(sr, "_run", sched), \
+                patch.object(sr.sys, "platform", "win32"), \
+                patch.object(sr, "is_live_python", lambda pid: False):
+            assert sr.stop_detached(log_dir) == 0
+        assert len(sched.ends()) == 1, sched.calls
+
+
+class TestTheEndIsNeverByNameAlone:
+    def test_no_end_without_a_preceding_query(self, repo, log_dir):
+        """Pinned at the call order: every End is preceded by the query that
+        justifies it."""
+        sched = _Scheduler(task_repo=str(repo))
+        with patch.object(sr, "_run", sched), \
+                patch.object(sr.sys, "platform", "win32"), \
+                patch.object(sr, "is_live_python", lambda pid: False):
+            sr.kill_roll(repo, log_dir, 1)
+            sr.stop_detached(log_dir, repo_root=repo)
+        verbs = [c[1] for c in sched.calls if c[0] == "schtasks"]
+        for i, verb in enumerate(verbs):
+            if verb == "/End":
+                assert verbs[i - 1] == "/Query", verbs

--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -46,14 +46,25 @@ def repo(tmp_path):
 class _Recorder:
     """Stands in for _run, recording argv and replaying scripted exit codes."""
 
-    def __init__(self, codes=None):
+    def __init__(self, codes=None, task_repo=None):
         self.calls = []
         self.codes = codes or {}
+        # #2831: what the scheduler says the task was registered for. A stop
+        # ends the task only when this names the repo being stopped; None
+        # plays a scheduler that cannot say.
+        self.task_repo = task_repo
 
     def __call__(self, cmd, cwd=None):
         self.calls.append(cmd)
         code = self.codes.get(cmd[1] if len(cmd) > 1 else "", 0)
-        return subprocess.CompletedProcess(cmd, code, stdout="", stderr="boom")
+        stdout = ""
+        if cmd[:2] == ["schtasks", "/Query"] and "/V" in cmd and self.task_repo:
+            stdout = (
+                "TaskName:      \\AZ-SpeedrunRoll\n"
+                f"Task To Run:   pythonw.exe speedrun_roll.py --repo {self.task_repo} "
+                "--issue 7 --log-dir x\n"
+            )
+        return subprocess.CompletedProcess(cmd, code, stdout=stdout, stderr="boom")
 
     def schtasks(self, verb):
         return [c for c in self.calls if c[0] == "schtasks" and c[1] == verb]
@@ -292,12 +303,15 @@ class TestStoppingADetachedRoll:
 
     def test_the_task_is_ended_after_the_tree_is_killed(self, repo, runs):
         runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
-        rec = _Recorder()
+        rec = _Recorder(task_repo=repo)
         with patch.object(sr, "is_live_python", lambda pid: True):
             self._stop(repo, rec)
 
         order = [c[0] for c in rec.calls if c[0] in ("taskkill", "schtasks")]
-        assert order == ["taskkill", "schtasks"], order
+        # #2831: the tree kill, then the query that proves the task is this
+        # repo's, then the End.
+        assert order == ["taskkill", "schtasks", "schtasks"], order
+        assert rec.schtasks("/End"), rec.calls
 
     def test_a_recycled_pid_is_not_killed(self, repo, runs):
         """Windows reuses pids. A stale file must never authorise tree-killing
@@ -318,8 +332,9 @@ class TestStoppingADetachedRoll:
         assert not pid.exists()
 
     def test_stopping_with_nothing_running_is_not_an_error(self, repo, runs):
-        rec = _Recorder(codes={"/End": 1})
+        rec = _Recorder(codes={"/End": 1}, task_repo=repo)
         assert self._stop(repo, rec) == 0
+        assert rec.schtasks("/End"), rec.calls
 
     def test_stopping_works_from_a_stale_tree(self, repo, runs):
         """Stopping is about processes, not code -- a staleness gate standing

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1792,7 +1792,7 @@ def is_live_python(pid: str) -> bool:
     return f'"{pid}"' in out and "python" in out.lower()
 
 
-def stop_detached(log_dir: Path) -> int:
+def stop_detached(log_dir: Path, repo_root: Path | None = None) -> int:
     """Stop a detached roll and everything it spawned (#2016).
 
     `schtasks /End` is not enough on its own: it ends the task's own process and
@@ -1834,10 +1834,11 @@ def stop_detached(log_dir: Path) -> int:
     else:
         print(f"No recorded pid at {path}.")
 
-    ended = _run(["schtasks", "/End", "/TN", TASK_NAME])
-    if ended.returncode != 0 and not killed:
+    # #2831: by name would end whatever roll is live on this machine.
+    ended, outcome = _end_task_for(repo_root or Path(log_dir).resolve().parents[2])
+    if not ended and not killed:
         log.write("DETACH-STOP nothing was running")
-        print(f"Task '{TASK_NAME}' was not running.")
+    print(outcome)
     return 0
 
 
@@ -1912,8 +1913,10 @@ def kill_roll(repo_root: Path, log_dir: Path, issue: int | None) -> int:
 
     if sys.platform == "win32":
         # Return the scheduled task to Ready when one was used. Absence is
-        # normal -- a foreground roll never registered one.
-        _run(["schtasks", "/End", "/TN", TASK_NAME])
+        # normal -- a foreground roll never registered one. #2831: only when
+        # the task is THIS repo's roll; the name is machine-global.
+        _ended, outcome = _end_task_for(repo_root)
+        print(f"  {outcome}")
 
     if stamped:
         print(f"Stamped '{KILLED_MARKER}' into {len(stamped)} run log(s).")
@@ -1962,6 +1965,50 @@ def _task_status() -> str:
         if len(fields) >= 3 and TASK_NAME in fields[0]:
             return fields[-1]
     return ""
+
+
+def _task_names_repo(repo_root: Path) -> bool | None:
+    """Whether the scheduled task on this machine was registered for `repo_root`.
+
+    #2831: the task name is machine-global -- there is one AZ-SpeedrunRoll --
+    so ending it by name ends whatever roll is live. On 2026-09-05 a unit test
+    killing its own tmp roll ended the operator's live run 13 that way, which
+    is the #2510 wrapper death. The task's own "Task To Run" carries the
+    `--repo` it was launched for; end it only when that names this repo.
+    None when schtasks cannot say, which is not a licence to end it.
+    """
+    result = _run(["schtasks", "/Query", "/TN", TASK_NAME, "/V", "/FO", "LIST"])
+    if result.returncode != 0:
+        return None
+    wanted = str(Path(repo_root).resolve()).lower().replace("/", "\\")
+    for line in (result.stdout or "").splitlines():
+        if line.strip().startswith("Task To Run:"):
+            command = line.split(":", 1)[1].lower().replace("/", "\\")
+            return wanted in command
+    return None
+
+
+def _end_task_for(repo_root: Path) -> tuple[bool, str]:
+    """End the scheduled task only when it is this repo's roll.
+
+    Returns (ended, what happened) so the caller can log and print the
+    outcome in one line each.
+    """
+    ours = _task_names_repo(repo_root)
+    if ours is None:
+        return False, (
+            f"Task '{TASK_NAME}' not ended: schtasks could not say which "
+            "repository it runs."
+        )
+    if not ours:
+        return False, (
+            f"Task '{TASK_NAME}' not ended: it is running another repository's "
+            f"roll, not {repo_root}."
+        )
+    ended = _run(["schtasks", "/End", "/TN", TASK_NAME])
+    if ended.returncode != 0:
+        return False, f"Task '{TASK_NAME}' was not running."
+    return True, f"Task '{TASK_NAME}' ended."
 
 
 def _task_last_result() -> int | None:
@@ -3475,7 +3522,7 @@ def main(argv: list[str] | None = None) -> int:
         return kill_roll(repo_root, log_dir, args.issue[0] if args.issue else None)
 
     if args.detach_stop:
-        return stop_detached(log_dir)
+        return stop_detached(log_dir, repo_root=repo_root)
 
     # #2138 / standard 0026: a viewer, not a launcher. It spends nothing and
     # runs no gates, so it must work even when a gate would refuse a launch.


### PR DESCRIPTION
Closes #2831

## The #2510 wrapper deaths have a mechanism

Run 13's wrapper died at 01:59:21 on 2026-09-05. Task Scheduler's record for `AZ-SpeedrunRoll`: Last Result **267014** (0x41306, "terminated by the user"). The task's XML rules out every automatic stop — `StopIfGoingOnBatteries` false, `StopOnIdleEnd` false, `ExecutionTimeLimit` PT0S. Something ran `schtasks /End /TN AZ-SpeedrunRoll`.

`kill_roll` and `stop_detached` both end the task **by name, unconditionally** — whatever repo, log dir or pid they were asked about. The name is machine-global: there is one `AZ-SpeedrunRoll` on this box, and it belongs to whichever roll is live. `tests/unit/test_emergency_stop_windows_paths.py:287` calls the real `kill_roll` against a tmp repo, a tmp log dir and a real spawned process with `_run` live — the point of that test is that `taskkill` really kills a tree. It also really ends the live roll's task. So does every local run of the unit suite on the rolling machine, and the orchestrator survives as an orphan, which is exactly #2510's shape. This session ran the suite at 01:58 and at 02:02.

## The End is scoped to the roll it was asked to stop

`_task_names_repo(repo_root)` reads the task's own "Task To Run" (`schtasks /Query /TN … /V /FO LIST`) and answers whether it carries this repository's path, slashes normalised; `None` when the scheduler cannot say. `_end_task_for(repo_root)` ends the task only on `True` and returns what happened for the log and the console. Both stop paths use it; `stop_detached` gains a `repo_root` argument (main passes it; derived from the log dir when absent).

A tmp repo never matches, so no test can reach the live task without also faking the query. Two repositories rolling concurrently would not end each other's task either.

## Tests

`tests/unit/test_kill_ends_only_its_own_task.py`, 14 tests: the question (ours, another's, slash-normalised, unqueryable, no line); `kill_roll` and `stop_detached` each against another repo's task (nothing ended, and the console says whose it is), their own (ended once), and an unqueryable scheduler (nothing ended, and it says it could not tell); the repo derived from the log dir; and a pin that every `/End` is immediately preceded by the `/Query` that justifies it. `test_speedrun_roll_detach.py`'s recorder now answers the query with the repo it stands in for, so the two tests that expect an End still see one — after the query.

Suites touching the stop paths (detach, kill, follow, emergency stop): 118 passed, 2 skipped. Ruff clean.

## Not changed

The tree kill itself. The test at `test_emergency_stop_windows_paths.py:287` still kills its real spawned tree; it can no longer reach the live task, which is the point.
