### PR TITLE
fix: the design reviewer's own template is read as a verdict, and an unreadable answer is re-asked once before it ends the run (Closes #2835)

### DIFF
--- a/assemblyzero/core/verdict_schema.py
+++ b/assemblyzero/core/verdict_schema.py
@@ -407,6 +407,108 @@ def scan_open_questions_section(text: str) -> DraftQuestionsResult:
     return DraftQuestionsResult(open_questions=open_questions, source="document_scan")
 
 
+#: The verdict checkboxes the LLD review template (docs/skills/0702c) scaffolds.
+#: A closed set: the reader accepts exactly one checked box and nothing else.
+_TEMPLATE_VERDICTS = ("APPROVED", "REVISE", "DISCUSS")
+
+#: What a template subsection says when there is nothing wrong.
+_TEMPLATE_NO_ISSUE = frozenset({"no issues found", "no blocking issues found"})
+
+
+def _template_section_lines(text: str, title: str):
+    """Yield the body lines of the template section whose heading starts with
+    ``title``, INCLUDING lines under its own sub-headings.
+
+    ``_iter_section_lines`` stops at any heading; the review template nests
+    ``### Cost`` / ``### Safety`` under ``## Tier 1``, so a Tier walk has to
+    carry on through headings deeper than the one it opened with and stop at
+    the next heading of the same or a shallower level.
+    """
+    wanted = title.casefold()
+    level = 0
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            depth = len(stripped) - len(stripped.lstrip("#"))
+            heading = stripped.lstrip("#").strip().rstrip(":").casefold()
+            if level and depth <= level:
+                level = 0
+            if not level and heading.startswith(wanted):
+                level = depth
+                continue
+        if level:
+            yield stripped
+
+
+def _checked_verdict(line: str) -> str | None:
+    """The verdict word on a checked template line (``[x] **REVISE** - …``)."""
+    stripped = line.strip()
+    if stripped.startswith("-"):
+        stripped = stripped[1:].strip()
+    if stripped[:3].casefold() != "[x]":
+        return None
+    rest = stripped[3:].strip().lstrip("*").strip().upper()
+    for verdict in _TEMPLATE_VERDICTS:
+        if rest.startswith(verdict):
+            return verdict
+    return None
+
+
+def _template_items(text: str, title: str) -> list[str]:
+    """The bullets under a Tier section that are findings, not placeholders."""
+    items: list[str] = []
+    for line in _template_section_lines(text, title):
+        if not line.startswith("-"):
+            continue
+        body = line[1:].strip()
+        if body[:3] in ("[ ]", "[x]", "[X]"):
+            body = body[3:].strip()
+        bare = body.strip("*_`").strip().rstrip(".!").casefold()
+        if not body or bare in _TEMPLATE_NO_ISSUE or is_none_placeholder(body):
+            continue
+        items.append(body)
+    return items
+
+
+def parse_markdown_feedback(raw: str) -> FeedbackResult | None:
+    """Read a design review written in the fleet's own 0702c template (#2835).
+
+    The reviewer is handed that template as its Review Instructions and, at
+    the transport, a directive to answer as one JSON object. On 2026-09-05
+    run 14 it followed the template, and the run ended on a verdict that was
+    fully legible. Standard 0028 §3 permits a deterministic walk of OUR OWN
+    markdown format; this is that walk, over headings 0702c defines:
+
+    - ``verdict``: the single checked box under ``## Verdict``;
+    - ``feedback_items``: the bullets under ``## Tier 1`` and ``## Tier 2``
+      that are not "No issues found" placeholders;
+    - ``open_questions``: the checkbox scan of ``## Open Questions Resolved``;
+    - ``rationale``: the whole text, so the node's own Tier arithmetic
+      (#1511) reads it exactly as it reads a JSON rationale.
+
+    None when there is not exactly one checked verdict -- the reader does
+    not guess, and the caller re-asks.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    checked = [
+        verdict for verdict in (
+            _checked_verdict(line) for line in _template_section_lines(text, "verdict")
+        ) if verdict
+    ]
+    if len(checked) != 1:
+        return None
+    return FeedbackResult(
+        verdict=checked[0],
+        rationale=text,
+        feedback_items=_template_items(text, "tier 1") + _template_items(text, "tier 2"),
+        open_questions=scan_open_questions_section(text)["open_questions"],
+        resolved_issues=[],
+        source="markdown_template",
+    )
+
+
 def scan_residual_questions(text: str) -> FinalizeQuestionsResult:
     """Deterministic residual question/TODO scan of generated content.
 

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -17,12 +17,11 @@ from typing import Any
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
 from assemblyzero.core.verdict_schema import (
-    VERDICT_SCHEMA,
     FEEDBACK_SCHEMA,
     FeedbackResult,
     StructuredContractError,
     is_none_placeholder,
-    parse_structured_verdict,
+    parse_markdown_feedback,
     parse_structured_feedback,
     scan_open_questions_section,
 )
@@ -100,7 +99,51 @@ def _invoke_reviewer_with_feedback_schema(
     # Issue #1843: the payload lives on .response — `.content` never existed,
     # so parses ran against the stringified dataclass and always fell back.
     raw = getattr(result, "response", None) or ""
-    return parse_structured_feedback(raw)
+    try:
+        return parse_structured_feedback(raw)
+    except StructuredContractError as first:
+        # #2835: the Review Instructions hand the reviewer the 0702c markdown
+        # template and the transport asks for JSON; when it follows the
+        # template (run 14, 2026-09-05) the verdict is fully legible and is
+        # read as our own format (standard 0028 §3).
+        template = parse_markdown_feedback(raw)
+        if template is not None:
+            print(
+                "    [N3] verdict read from the 0702c review template, not JSON "
+                f"(#2835): {template['verdict']}"
+            )
+            return template
+        # Neither shape. One re-ask, naming the defect; then the rejection.
+        print(
+            "    [N3] reviewer answered in neither the JSON contract nor the "
+            "review template; asking once more for the JSON object (#2835)."
+        )
+        retry = provider.invoke(system + _REASK_FOR_JSON, prompt, **schema_kwargs)
+        raw_retry = getattr(retry, "response", None) or ""
+        try:
+            return parse_structured_feedback(raw_retry)
+        except StructuredContractError as second:
+            template = parse_markdown_feedback(raw_retry)
+            if template is not None:
+                print(
+                    "    [N3] re-asked verdict read from the 0702c review template "
+                    f"(#2835): {template['verdict']}"
+                )
+                return template
+            raise StructuredContractError(
+                "feedback",
+                f"unreadable twice -- first: {first.reason}; re-ask: {second.reason}",
+                raw_retry,
+            ) from second
+
+
+#: Appended to the system prompt for the one re-ask (#2835).
+_REASK_FOR_JSON = (
+    "\n\nYour previous answer was neither the JSON object the Response Format "
+    "section requires nor the review template. Answer again with ONLY that "
+    "JSON object: keys verdict (APPROVED, REVISE or DISCUSS), rationale, "
+    "feedback_items, open_questions."
+)
 
 
 def review(state: RequirementsWorkflowState) -> dict[str, Any]:
@@ -629,7 +672,7 @@ def _extract_actionable_feedback(
         if suggestions:
             parts.append(f"## Suggestions\n{suggestions}")
         if parts:
-            return f"Verdict: APPROVED\n\n" + "\n\n".join(parts)
+            return "Verdict: APPROVED\n\n" + "\n\n".join(parts)
         return "Verdict: APPROVED. No changes needed."
 
     # For BLOCKED/REVISE: extract all actionable feedback

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8860,
+    "sites_examined": 8886,
     "findings_total": 533
   },
   "undeclared": [

--- a/tests/fixtures/lld_review_shapes/run14-markdown-template.txt
+++ b/tests/fixtures/lld_review_shapes/run14-markdown-template.txt
@@ -1,0 +1,50 @@
+# LLD Review: #4-Feature: Windows data collector — ConPTY, processes, memory, handles
+
+## Identity Confirmation
+I am Gemini 3 Pro, acting as Senior Software Architect & AI Governance Lead.
+
+## Pre-Flight Gate
+PASSED
+
+## Review Summary
+The LLD provides a well-structured and highly optimized approach to Windows metric collection using `NtQuerySystemInformation` to meet strict performance budgets. However, it contains a blocking Safety issue regarding thread failure handling and lacks adequate observability for the background daemon. 
+
+## Open Questions Resolved
+No open questions found in Section 1.
+
+## Tier 1: BLOCKING Issues
+
+### Cost
+- [ ] No issues found.
+
+### Safety
+- [ ] **Silent Failure / Fail-Safe Strategy:** Section 7.2 states "The thread must be restarted if an unhandled OS error occurs", but the proposed `DataCollector` interface provides no mechanism for the Main GUI thread to detect that the background thread has died (e.g., an `is_alive()` method, or pushing a fatal error sentinel to the queue). If the thread crashes, it constitutes a silent failure where the GUI simply starves for new data. Add a mechanism for thread health monitoring or an auto-restart loop within the daemon.
+
+### Security
+- [ ] No issues found.
+
+### Legal
+- [ ] No issues found.
+
+## Tier 2: HIGH PRIORITY Issues
+
+### Architecture
+- [ ] No issues found.
+
+### Observability
+- [ ] **Missing Logging Strategy:** The LLD explicitly states that exceptions for process rows terminating early should "continue silently" (Section 7.2). Additionally, unhandled thread crashes have no defined logging. Add a logging strategy (e.g., `logging.debug` for `AccessDenied` and `logging.exception` at the top level of the thread's run loop) so that background collection failures can be debugged without attaching a live debugger.
+
+### Quality
+- [ ] No issues found.
+
+## Tier 3: SUGGESTIONS
+- **Queue Initialization:** Explicitly specify the `maxsize` of the bounded queue in the `DataCollector` initialization to clarify the memory bounds.
+- **Regex/String Matching:** If using a regular expression to match the `unleashed-c-*.py` signature, ensure it is compiled once during `WindowsCollector` initialization rather than per-tick to maintain the strict < 20ms performance budget.
+
+## Questions for Orchestrator
+1. Should there be an explicit retry backoff mechanism if the `NtQuerySystemInformation` API consistently returns unhandled OS errors, to prevent aggressive CPU spinning on failure during a thread auto-restart?
+
+## Verdict
+[ ] **APPROVED** - Ready for implementation
+[x] **REVISE** - Fix Tier 1/2 issues first
+[ ] **DISCUSS** - Needs Orchestrator decision

--- a/tests/unit/test_lld_review_reads_template.py
+++ b/tests/unit/test_lld_review_reads_template.py
@@ -1,0 +1,171 @@
+"""#2835: the design reviewer's own template is a readable verdict.
+
+Run 14 on boostgauge #4 (`run-issue4-023537`, 2026-09-05) cleared the
+requirements gate and the design draft, then the reviewer answered in the
+0702c markdown template it had been handed as its instructions -- Identity
+Confirmation, Pre-Flight Gate, Tier 1/2/3, a checked `[x] **REVISE**` -- and
+`parse_structured_feedback` refused it for not being JSON. The run ended
+with a usable verdict in the log. That response is the fixture here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from assemblyzero.core.verdict_schema import (
+    StructuredContractError,
+    parse_markdown_feedback,
+)
+from assemblyzero.workflows.requirements.nodes.review import (
+    _count_tier1_blocking_issues,
+    _invoke_reviewer_with_feedback_schema,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures" / "lld_review_shapes" / "run14-markdown-template.txt"
+)
+RUN14 = FIXTURE.read_text(encoding="utf-8")
+
+APPROVED_TEMPLATE = """\
+# LLD Review: #7
+
+## Identity Confirmation
+I am Gemini 3 Pro.
+
+## Pre-Flight Gate
+PASSED
+
+## Review Summary
+Clean.
+
+## Open Questions Resolved
+- [x] ~~Which config format?~~ **RESOLVED: TOML.**
+
+## Tier 1: BLOCKING Issues
+
+### Cost
+- [ ] No issues found.
+
+### Safety
+- [ ] No issues found.
+
+## Tier 2: HIGH PRIORITY Issues
+
+### Architecture
+- [ ] No issues found.
+
+## Tier 3: SUGGESTIONS
+- Consider a docstring.
+
+## Verdict
+[x] **APPROVED** - Ready for implementation
+[ ] **REVISE** - Fix Tier 1/2 issues first
+[ ] **DISCUSS** - Needs Orchestrator decision
+"""
+
+
+class TestRun14sAnswerIsAVerdict:
+    def test_it_reads_as_revise_with_two_items(self):
+        parsed = parse_markdown_feedback(RUN14)
+        assert parsed is not None, "run 14's reviewer answer was thrown away"
+        assert parsed["verdict"] == "REVISE"
+        assert parsed["source"] == "markdown_template"
+        assert len(parsed["feedback_items"]) == 2
+        assert "Silent Failure" in parsed["feedback_items"][0]
+        assert "Missing Logging Strategy" in parsed["feedback_items"][1]
+        assert parsed["open_questions"] == []
+
+    def test_the_rationale_carries_the_tier_headings_the_node_reads(self):
+        parsed = parse_markdown_feedback(RUN14)
+        assert parsed is not None
+        assert "## Tier 1: BLOCKING Issues" in parsed["rationale"]
+        assert "## Tier 2:" in parsed["rationale"]
+        # #1511's own arithmetic on that rationale: one real Tier 1 issue,
+        # so the node lands on BLOCKED and the revision loop runs.
+        assert _count_tier1_blocking_issues(parsed["rationale"]) == 1
+
+    def test_an_approved_template_is_approved_with_no_items(self):
+        parsed = parse_markdown_feedback(APPROVED_TEMPLATE)
+        assert parsed is not None
+        assert parsed["verdict"] == "APPROVED"
+        assert parsed["feedback_items"] == []
+        assert parsed["open_questions"] == [
+            {"text": "~~Which config format?~~ **RESOLVED: TOML.**", "resolved": True}
+        ]
+        assert _count_tier1_blocking_issues(parsed["rationale"]) == 0
+
+
+class TestTheReaderDoesNotGuess:
+    def test_no_checked_verdict_is_not_read(self):
+        text = RUN14.replace("[x] **REVISE**", "[ ] **REVISE**")
+        assert parse_markdown_feedback(text) is None
+
+    def test_two_checked_verdicts_are_not_read(self):
+        text = RUN14.replace("[ ] **APPROVED**", "[x] **APPROVED**")
+        assert parse_markdown_feedback(text) is None
+
+    @pytest.mark.parametrize("raw", ["", "   ", "just prose", "{\"verdict\": \"APPROVED\"}"])
+    def test_nothing_template_shaped_is_none(self, raw):
+        assert parse_markdown_feedback(raw) is None
+
+
+class _Scripted:
+    """A provider that answers from a list and counts its calls."""
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.calls: list[tuple[str, str]] = []
+
+    def invoke(self, system, prompt, **_kwargs):
+        self.calls.append((system, prompt))
+        return SimpleNamespace(response=self.answers.pop(0))
+
+
+JSON_ANSWER = json.dumps({
+    "verdict": "APPROVED",
+    "rationale": "## Tier 1: BLOCKING Issues\n- [ ] No issues found.\n## Tier 2: HIGH PRIORITY Issues\n- [ ] No issues found.",
+    "feedback_items": [],
+    "open_questions": [],
+})
+
+
+class TestTheHelperAsksAtMostTwice:
+    def test_json_first_time_is_one_call(self):
+        provider = _Scripted([JSON_ANSWER])
+        result = _invoke_reviewer_with_feedback_schema(provider, "draft", "system")
+        assert result["verdict"] == "APPROVED"
+        assert len(provider.calls) == 1
+
+    def test_the_template_first_time_is_one_call(self, capsys):
+        provider = _Scripted([RUN14])
+        result = _invoke_reviewer_with_feedback_schema(provider, "draft", "system")
+        assert result["verdict"] == "REVISE"
+        assert len(provider.calls) == 1
+        assert "0702c review template" in capsys.readouterr().out
+
+    def test_garbage_then_json_is_two_calls_and_the_second_names_the_defect(self):
+        provider = _Scripted(["I decline to answer in any format.", JSON_ANSWER])
+        result = _invoke_reviewer_with_feedback_schema(provider, "draft", "system")
+        assert result["verdict"] == "APPROVED"
+        assert len(provider.calls) == 2
+        assert "ONLY that JSON object" in provider.calls[1][0]
+        assert provider.calls[1][0].startswith("system")
+
+    def test_garbage_then_template_is_read(self):
+        provider = _Scripted(["nothing here", RUN14])
+        result = _invoke_reviewer_with_feedback_schema(provider, "draft", "system")
+        assert result["verdict"] == "REVISE"
+        assert len(provider.calls) == 2
+
+    def test_garbage_twice_is_still_rejected_and_never_a_third_call(self):
+        provider = _Scripted(["nothing here", "still nothing"])
+        with pytest.raises(StructuredContractError) as excinfo:
+            _invoke_reviewer_with_feedback_schema(provider, "draft", "system")
+        assert "unreadable twice" in str(excinfo.value)
+        assert len(provider.calls) == 2
+        assert provider.answers == []


### PR DESCRIPTION
Closes #2835

## Run 14 died on a verdict it could read

Run 14 on boostgauge #4 (`run-issue4-023537`, 2026-09-05) cleared the requirements gate on the first answer and the design draft on the first pass, then halted in the design review after one call: `structured contract violated in feedback: no JSON object found in response`. The reviewer's answer — recorded by #2731 and now a fixture — is a complete review in the fleet's own template: Identity Confirmation, Pre-Flight Gate, one Tier 1 issue (no way for the GUI to notice a dead collector thread), one Tier 2, Tier 3, and `## Verdict` with `[x] **REVISE**`.

It was told to write exactly that. `docs/skills/0702c-LLD-Review-Prompt.md`, sent as the Review Instructions, opens with *"Identity Handshake: Begin your response by confirming your identity as Gemini 3 Pro"* and ends with that template, checkboxes included; the transport then appends #1843's *"Respond with a SINGLE JSON object … no markdown headings"*. Two shapes in one prompt. On runs 8–12 the model chose JSON and put the template inside `rationale` (which the node reads for `## Tier 1: BLOCKING Issues`, so the template is load-bearing either way); tonight it chose the template, the node returned an error, the orchestrator called it non-transient, and the run ended at 02:42.

## The template is read as our own format

Standard 0028 §3 permits a deterministic walk of OUR OWN markdown format, headings the templates define. `parse_markdown_feedback` in `verdict_schema.py` is that walk over 0702c's headings: the verdict is the single checked box under `## Verdict`; `feedback_items` are the bullets under `## Tier 1` and `## Tier 2` that are not "No issues found" placeholders (walking through the template's `### Cost` / `### Safety` sub-headings, which the existing section iterator stops at); `open_questions` is the existing checkbox scan of `## Open Questions Resolved`; `rationale` is the whole text, so the node's #1511 Tier arithmetic reads it exactly as it reads a JSON rationale. `None` when there is not exactly one checked verdict — the reader does not guess.

`_invoke_reviewer_with_feedback_schema` now: JSON first; then the template; then **one** re-ask whose system prompt names the defect and asks for only the JSON object; then the template again on that answer; then the rejection as today. Two calls at most, the second only when the first was unreadable both ways.

## Tests

`tests/unit/test_lld_review_reads_template.py`, 14 tests. Run 14's answer reads as `REVISE` with two items and no open questions, and its rationale carries both Tier headings so `_count_tier1_blocking_issues` returns 1 — through the node's own logic that is `BLOCKED` with one Tier 1 issue: the revision loop, not a halt. An APPROVED template with placeholders throughout is `APPROVED` with no items and one resolved question. No checked box, two checked boxes, and nothing template-shaped are `None`. The helper: JSON first time is one call; the template first time is one call; garbage then JSON is two calls and the second names the defect; garbage then the template is read; garbage twice raises `StructuredContractError` after exactly two calls.

Twenty suites touching the review node and the verdict schema: 1,006 passed. The fail-open denominator follows the new sites; no new fail-open site. Ruff clean, including three pre-existing findings in `review.py` (two unused imports, one placeholder-free f-string).

## Not changed

0702c and the transport's JSON directive still contradict each other; which shape wins is a prompt ruling and is the follow-up named on #2835. Tonight the reader accepts both.
