### PR TITLE
fix: the spec and test-plan reviewers' own templates are read as verdicts, with one re-ask before a halt (Closes #2837)

### DIFF
--- a/assemblyzero/core/verdict_schema.py
+++ b/assemblyzero/core/verdict_schema.py
@@ -440,7 +440,7 @@ def _template_section_lines(text: str, title: str):
             yield stripped
 
 
-def _checked_verdict(line: str) -> str | None:
+def _checked_verdict(line: str, allowed: tuple[str, ...] = _TEMPLATE_VERDICTS) -> str | None:
     """The verdict word on a checked template line (``[x] **REVISE** - …``)."""
     stripped = line.strip()
     if stripped.startswith("-"):
@@ -448,10 +448,21 @@ def _checked_verdict(line: str) -> str | None:
     if stripped[:3].casefold() != "[x]":
         return None
     rest = stripped[3:].strip().lstrip("*").strip().upper()
-    for verdict in _TEMPLATE_VERDICTS:
+    for verdict in allowed:
         if rest.startswith(verdict):
             return verdict
     return None
+
+
+def _single_checked_verdict(text: str, allowed: tuple[str, ...]) -> str | None:
+    """The one checked box under ``## Verdict``, or None when there is not exactly one."""
+    checked = [
+        verdict for verdict in (
+            _checked_verdict(line, allowed)
+            for line in _template_section_lines(text, "verdict")
+        ) if verdict
+    ]
+    return checked[0] if len(checked) == 1 else None
 
 
 def _template_items(text: str, title: str) -> list[str]:
@@ -507,6 +518,125 @@ def parse_markdown_feedback(raw: str) -> FeedbackResult | None:
         resolved_issues=[],
         source="markdown_template",
     )
+
+
+#: The spec review template (``review_spec._get_output_format``) and the
+#: test-plan review template (``review_test_plan``) scaffold these boxes.
+_TEMPLATE_VERDICTS_SPEC = ("APPROVED", "REVISE", "BLOCKED")
+_TEMPLATE_VERDICTS_PLAN = ("APPROVED", "BLOCKED", "REVISE")
+
+#: What those templates write in a section that has nothing to report.
+_TEMPLATE_EMPTY = frozenset({
+    "no issues found",
+    "no blocking issues found",
+    "no high-priority issues found",
+    "no high priority issues found",
+    "none",
+})
+
+
+def _template_entries(text: str, title: str) -> list[str]:
+    """The numbered or bulleted entries under a template section, each with
+    its continuation lines and code fences, minus the "No … found" placeholders.
+
+    An entry begins at ``1.`` / ``2.`` / ``- `` outside a code fence and runs
+    to the next such line or the end of the section. Continuation lines keep
+    their text (the section walk strips indentation), which is what the
+    revision lock needs: the cited names and spans, verbatim.
+    """
+    entries: list[str] = []
+    current: list[str] = []
+    in_fence = False
+
+    def flush() -> None:
+        body = "\n".join(current).strip()
+        current.clear()
+        if not body:
+            return
+        bare = body.strip("*_`").strip().rstrip(".!").casefold()
+        if bare in _TEMPLATE_EMPTY or is_none_placeholder(body):
+            return
+        entries.append(body)
+
+    for line in _template_section_lines(text, title):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            current.append(line)
+            continue
+        if in_fence:
+            current.append(line)
+            continue
+        head = line.split(".", 1)[0]
+        starts_entry = line.startswith("- ") or (
+            head.isdigit() and line[len(head):][:1] == "."
+        )
+        if starts_entry:
+            flush()
+            current.append(line[2:].strip() if line.startswith("- ") else line.split(".", 1)[1].strip())
+        elif current:
+            current.append(line)
+        elif line:
+            # Prose before any entry ("No blocking issues found.") is one entry
+            # of its own, so the placeholder filter can see it.
+            current.append(line)
+            flush()
+    flush()
+    return entries
+
+
+def parse_markdown_review_spec(raw: str) -> ReviewSpecResult | None:
+    """Read a spec review written in ``review_spec``'s own output template
+    (#2837): ``## Summary``, ``## Blocking Issues``, ``## High Priority
+    Issues``, ``## Suggestions``, ``## Verdict`` with one box marked ``[X]``.
+
+    The reviewer is told "You MUST structure your review as follows" and
+    shown that template, while the transport asks for a JSON object; on
+    2026-09-05 run 15 it followed the template and the run ended on a verdict
+    that named run 11's tolerance defect on round 1. Standard 0028 §3: a
+    deterministic walk of our own format is a parse. None when there is not
+    exactly one checked verdict.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    verdict = _single_checked_verdict(text, _TEMPLATE_VERDICTS_SPEC)
+    if verdict is None:
+        return None
+    summary = "\n".join(
+        line for line in _template_section_lines(text, "summary") if line
+    ).strip()
+    return ReviewSpecResult(
+        verdict=verdict,
+        rationale=summary or text,
+        feedback_items=(
+            _template_entries(text, "blocking issues")
+            + _template_entries(text, "high priority issues")
+        ),
+        source="markdown_template",
+    )
+
+
+def parse_markdown_verdict(raw: str) -> dict | None:
+    """Read a test-plan review written in ``review_test_plan``'s own template
+    (#2837): ``## Coverage Analysis``, ``## Test Reality Issues``,
+    ``## Verdict`` with one box marked ``[X]``, ``## Required Changes``.
+
+    Same shape as ``parse_structured_verdict``'s result, so the node reads it
+    unchanged. None when there is not exactly one checked verdict.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    verdict = _single_checked_verdict(text, _TEMPLATE_VERDICTS_PLAN)
+    if verdict is None:
+        return None
+    return {
+        "verdict": verdict,
+        "rationale": text,
+        "blocking_issues": [],
+        "suggestions": _template_entries(text, "required changes"),
+        "source": "markdown_template",
+    }
 
 
 def scan_residual_questions(text: str) -> FinalizeQuestionsResult:

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -32,6 +32,7 @@ from assemblyzero.core.verdict_schema import (
     REVIEW_SPEC_SCHEMA,
     ReviewSpecResult,
     StructuredContractError,
+    parse_markdown_review_spec,
     parse_structured_review_spec,
 )
 from assemblyzero.workflows.requirements.audit import (
@@ -178,8 +179,53 @@ def _invoke_reviewer_with_spec_schema(
     # surfaces it and the stage retry re-asks. No regex fallback exists.
     try:
         return parse_structured_review_spec(raw), ""
-    except StructuredContractError as e:
-        return None, str(e)
+    except StructuredContractError as first:
+        # #2837: the prompt's own "Required Output Format" is a markdown
+        # template; when the reviewer follows it (run 15, 2026-09-05) the
+        # verdict is fully legible and is read as our own format (0028 §3).
+        template = parse_markdown_review_spec(raw)
+        if template is not None:
+            print(
+                "    [N5] verdict read from the review's own output template, "
+                f"not JSON (#2837): {template['verdict']}"
+            )
+            return template, ""
+        # Neither shape. One re-ask naming the defect; then the rejection.
+        print(
+            "    [N5] reviewer answered in neither the JSON contract nor the "
+            "output template; asking once more for the JSON object (#2837)."
+        )
+        retry = provider.invoke(system + _REASK_FOR_JSON, prompt, **schema_kwargs)
+        if not getattr(retry, "success", False):
+            detail = getattr(retry, "error_message", None) or "LLM call failed with no error detail"
+            return None, str(detail)
+        raw_retry = getattr(retry, "response", None) or ""
+        try:
+            return parse_structured_review_spec(raw_retry), ""
+        except StructuredContractError as second:
+            # fail-open: not open -- the rejection is returned as (None, error)
+            # for the caller to surface, exactly as the first handler above
+            # does; the node halts on it. Declared so the audit sees the pair.
+            template = parse_markdown_review_spec(raw_retry)
+            if template is not None:
+                print(
+                    "    [N5] re-asked verdict read from the review's own output "
+                    f"template (#2837): {template['verdict']}"
+                )
+                return template, ""
+            return None, (
+                f"unreadable twice -- first: {first.reason}; re-ask: {second.reason}"
+                f" | response begins: {second.excerpt!r}"
+            )
+
+
+#: Appended to the system prompt for the one re-ask (#2837).
+_REASK_FOR_JSON = (
+    "\n\nYour previous answer was neither the JSON object the Response Format "
+    "section requires nor the Required Output Format template. Answer again "
+    "with ONLY that JSON object: keys verdict (APPROVED, REVISE or BLOCKED), "
+    "rationale, feedback_items."
+)
 
 
 # =============================================================================

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -214,7 +214,8 @@ def _invoke_reviewer_with_spec_schema(
                 )
                 return template, ""
             return None, (
-                f"unreadable twice -- first: {first.reason}; re-ask: {second.reason}"
+                "structured contract violated in review_spec: unreadable twice -- "
+                f"first: {first.reason}; re-ask: {second.reason}"
                 f" | response begins: {second.excerpt!r}"
             )
 

--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -21,6 +21,7 @@ from typing import Any
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
+    parse_markdown_verdict,
     parse_structured_verdict,
 )
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
@@ -593,6 +594,12 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
     # rejected loudly and the stage retry machinery re-asks. The regex
     # fallback (which silently downgraded garbage to BLOCKED) is retired.
     structured = parse_structured_verdict(verdict_content)
+    if not structured:
+        # #2837: the prompt's own "Output Format" is a markdown template with
+        # one box to mark; when the reviewer follows it, that is a verdict.
+        structured = parse_markdown_verdict(verdict_content)
+        if structured:
+            print("    [N1.5] verdict read from the review's own output template, not JSON (#2837)")
     if not structured:
         excerpt = verdict_content.strip().replace("\n", " ")[:160]
         msg = (

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8886,
-    "findings_total": 533
+    "sites_examined": 8917,
+    "findings_total": 534
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",
@@ -232,7 +232,6 @@
     "assemblyzero/workflows/implementation_spec/nodes/finalize_spec.py::finalize_spec::except_handler::0",
     "assemblyzero/workflows/implementation_spec/nodes/retry_prompt_builder.py::_estimate_tokens::except_handler::0",
     "assemblyzero/workflows/implementation_spec/nodes/review_spec.py::_file_conflict_if_any::except_handler::0",
-    "assemblyzero/workflows/implementation_spec/nodes/review_spec.py::_invoke_reviewer_with_spec_schema::except_handler::0",
     "assemblyzero/workflows/implementation_spec/nodes/review_spec.py::review_spec::except_handler::0",
     "assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py::_discover_pyproject_source_roots::except_handler::0",
     "assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py::_first_party_tops::except_handler::0",

--- a/tests/fixtures/spec_review_shapes/run15-markdown-template.txt
+++ b/tests/fixtures/spec_review_shapes/run15-markdown-template.txt
@@ -1,0 +1,29 @@
+## Readiness Review: Issue #4
+
+## Summary
+The revised spec correctly implements the architectural structure, API boundaries, and resolves the test scoping issues from the prior iteration. However, two test cases introduce assertion traceability violations by enforcing looser bounds than the requirements explicitly dictate, meaning an incorrect implementation could falsely pass the test suite. 
+
+## Blocking Issues
+No blocking issues found.
+
+## High Priority Issues
+1. **Test Assertion Contradicts Specification (REQ-2):** In `tests/integration/test_windows_collector.py`, `test_req_020` enforces a ±5 process tolerance and a 5% handle tolerance:
+   ```python
+   proc_match = abs(proc_ps - proc_sw) <= 5
+   hand_match = hand_ps > 0 and abs(hand_ps - hand_sw) / hand_ps <= 0.05 
+   ```
+   This directly contradicts the behaviour text in **REQ-2**, which explicitly dictates: *"Collector returns accurate process count (±1 against psutil) and handle count (within 1% of psutil's num_handles sum)"*. The assertions must be tightened to `<= 1` and `<= 0.01` respectively to trace accurately to the requirement.
+
+2. **Test Assertion Contradicts Specification (REQ-7):** In `tests/integration/test_windows_collector.py`, `test_req_070` asserts:
+   ```python
+   assert mock_ntdll.NtQuerySystemInformation.call_count >= 1
+   ```
+   This contradicts the explicit behaviour text in **Section 10.0 and 10.1 (T070)** which dictates: *"Call count to NtQuerySystemInformation == 1 per tick"*. Because the mock is set to return `0` (success on the first call, meaning no buffer resize loop is triggered), the test must assert exactly `== 1` to strictly enforce the "single sweep" constraint.
+
+## Suggestions
+- None. The rest of the implementation spec is very solid and provides concrete JSON/YAML examples alongside well-handled `ctypes` implementation logic.
+
+## Verdict
+[ ] **APPROVED** - Spec is ready for implementation
+[X] **REVISE** - Fix blocking/high-priority issues first
+[ ] **BLOCKED** - Fundamental issues prevent implementation

--- a/tests/unit/test_extract_and_discard.py
+++ b/tests/unit/test_extract_and_discard.py
@@ -117,16 +117,17 @@ class TestApprovedVerdictExtraction:
     @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
     @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
     def test_markdown_verdict_rejected_not_scraped(self, mock_root, mock_prompt, mock_log):
-        """Standard 0028: the old regex fallback scraped APPROVED from this
-        markdown; now a response with no schema-valid verdict is rejected
-        with an error the stage retry acts on — nothing is stored."""
+        """Standard 0028: the old regex fallback scraped APPROVED out of prose
+        like this; a response that is neither the JSON contract nor the
+        review's own template (#2837) is rejected with an error the stage
+        retry acts on — nothing is stored."""
         mock_root.return_value = Path("/tmp/test-repo")
         mock_prompt.return_value = "review prompt"
 
         mock_result = MagicMock()
         mock_result.success = True
         mock_result.content = ""
-        mock_result.response = "## Verdict\n[x] **APPROVED** - Test plan is ready.\n\nLong explanation here..." + ("x" * 500)
+        mock_result.response = "APPROVED. The test plan is ready.\n\nLong explanation here..." + ("x" * 500)
         mock_result.input_tokens = 100
         mock_result.output_tokens = 50
 
@@ -142,6 +143,40 @@ class TestApprovedVerdictExtraction:
 
         assert "rejected" in result.get("error_message", "")
         assert "test_plan_status" not in result
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_the_reviews_own_template_is_read_not_rejected(self, mock_root, mock_prompt, mock_log):
+        """#2837: the prompt's own Output Format is a markdown template with
+        one box to mark; a reviewer that follows it has given a verdict, and
+        the node reads it (standard 0028 §3) rather than ending the run."""
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.content = ""
+        mock_result.response = (
+            "## Coverage Analysis\n- Requirements covered: 2/2 (100%)\n\n"
+            "## Verdict\n[X] **APPROVED** - Test plan is ready for implementation\n"
+            "[ ] **BLOCKED** - Test plan needs revision\n"
+        )
+        mock_result.input_tokens = 100
+        mock_result.output_tokens = 50
+
+        mock_provider = MagicMock()
+        mock_provider.invoke.return_value = mock_result
+        with patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_provider", return_value=mock_provider), \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost", return_value=0.0), \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.check_requirement_coverage") as mock_cov:
+            mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
+
+            state = _make_state()
+            result = review_test_plan(state)
+
+        assert not result.get("error_message")
+        assert result["test_plan_status"] == "APPROVED"
 
 
 class TestFastPathCompliance:

--- a/tests/unit/test_extract_and_discard.py
+++ b/tests/unit/test_extract_and_discard.py
@@ -8,8 +8,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from assemblyzero.workflows.testing.nodes.review_test_plan import (
     review_test_plan,
     _mock_review_test_plan,
@@ -47,8 +45,6 @@ class TestBlockedVerdictExtraction:
         """Gemini BLOCKED → test_plan_verdict is short summary, not full response."""
         mock_root.return_value = Path("/tmp/test-repo")
         mock_prompt.return_value = "review prompt"
-
-        raw_prose = "A" * 500  # Long raw prose that should NOT appear in state
 
         mock_result = MagicMock()
         mock_result.success = True
@@ -258,7 +254,7 @@ class TestAuditFilePreservation:
                 mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
 
                 state = _make_state(audit_dir=tmpdir)
-                result = review_test_plan(state)
+                review_test_plan(state)
 
             # Verify save_audit_file was called with the FULL raw response
             verdict_calls = [

--- a/tests/unit/test_review_test_plan_structured_output.py
+++ b/tests/unit/test_review_test_plan_structured_output.py
@@ -80,8 +80,9 @@ def test_schema_valid_verdict_proceeds(
 def test_markdown_verdict_is_rejected_loudly(
     mock_cost, mock_provider, mock_with_retry, mock_root, mock_prompt, mock_log,
 ):
-    """The old regex fallback would have scraped APPROVED out of this
-    markdown; under standard 0028 the review is rejected with an error the
+    """The old regex fallback would have scraped APPROVED out of prose like
+    this; under standard 0028 a response that is neither the JSON contract
+    nor the review's own template (#2837) is rejected with an error the
     stage retry machinery acts on."""
     from assemblyzero.workflows.testing.nodes.review_test_plan import review_test_plan
     from assemblyzero.core.llm_provider import GeminiProvider
@@ -91,13 +92,44 @@ def test_markdown_verdict_is_rejected_loudly(
     mock_cost.return_value = 0.0
     mock_provider.return_value = MagicMock(spec=GeminiProvider)
     mock_with_retry.return_value = _llm_result(
-        "## Verdict\n[X] **APPROVED** — all good"
+        "APPROVED — all good, ship it."
     )
 
     result = review_test_plan(_state_forcing_llm_path())
     assert result.get("error_message"), "unparseable verdict must reject, not proceed"
     assert "rejected" in result["error_message"]
     assert "test_plan_status" not in result
+
+
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+@patch("assemblyzero.utils.retry.with_retry")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_provider")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost")
+def test_the_reviews_own_template_is_a_verdict(
+    mock_cost, mock_provider, mock_with_retry, mock_root, mock_prompt, mock_log,
+):
+    """#2837: the prompt's own Output Format is a markdown template with one
+    box to mark; a reviewer that follows it has answered, and the node reads
+    it as our own format (standard 0028 §3) instead of ending the run."""
+    from assemblyzero.workflows.testing.nodes.review_test_plan import review_test_plan
+    from assemblyzero.core.llm_provider import GeminiProvider
+
+    mock_root.return_value = Path("/tmp/test-repo")
+    mock_prompt.return_value = "review prompt"
+    mock_cost.return_value = 0.0
+    mock_provider.return_value = MagicMock(spec=GeminiProvider)
+    mock_with_retry.return_value = _llm_result(
+        "## Coverage Analysis\n- Requirements covered: 2/2 (100%)\n\n"
+        "## Verdict\n[ ] **APPROVED** - Test plan is ready for implementation\n"
+        "[X] **BLOCKED** - Test plan needs revision\n\n"
+        "## Required Changes (if BLOCKED)\n1. T030 must assert on a mocked virtual_memory().\n"
+    )
+
+    result = review_test_plan(_state_forcing_llm_path())
+    assert not result.get("error_message")
+    assert result["test_plan_status"] == "BLOCKED"
 
 
 @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")

--- a/tests/unit/test_spec_review_reads_template.py
+++ b/tests/unit/test_spec_review_reads_template.py
@@ -1,0 +1,186 @@
+"""#2837: the spec reviewer's own output template is a readable verdict.
+
+Run 15 on boostgauge #4 (`run-issue4-025552`, 2026-09-05) cleared every
+gate up to the spec review, then the reviewer answered in the "Required
+Output Format" `review_spec.py` hands it -- Summary, Blocking Issues, High
+Priority Issues, Suggestions, `[X] **REVISE**` -- and the JSON parser refused
+it. The verdict named run 11's tolerance defect on round 1. That response is
+the fixture here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from assemblyzero.core.verdict_schema import (
+    parse_markdown_review_spec,
+    parse_markdown_verdict,
+)
+from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+    _invoke_reviewer_with_spec_schema,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures" / "spec_review_shapes" / "run15-markdown-template.txt"
+)
+RUN15 = FIXTURE.read_text(encoding="utf-8")
+
+APPROVED_SPEC = """\
+## Readiness Review: Issue #7
+
+## Summary
+The spec is concrete and every test is executable.
+
+## Blocking Issues
+No blocking issues found.
+
+## High Priority Issues
+No high-priority issues found.
+
+## Suggestions
+- Consider naming the fixture.
+
+## Verdict
+[X] **APPROVED** - Spec is ready for implementation
+[ ] **REVISE** - Fix blocking/high-priority issues first
+[ ] **BLOCKED** - Fundamental issues prevent implementation
+"""
+
+PLAN_TEMPLATE = """\
+## Coverage Analysis
+- Requirements covered: 7/7 (100%)
+- Missing coverage: none
+
+## Test Reality Issues
+- none
+
+## Verdict
+[ ] **APPROVED** - Test plan is ready for implementation
+[X] **BLOCKED** - Test plan needs revision
+
+Mark EXACTLY ONE option with [X].
+
+## Required Changes (if BLOCKED)
+1. T030 must assert the memory field on a mocked virtual_memory().
+2. T070 must assert exactly one NtQuerySystemInformation call.
+"""
+
+
+class TestRun15sAnswerIsAVerdict:
+    def test_it_reads_as_revise_with_two_items(self):
+        parsed = parse_markdown_review_spec(RUN15)
+        assert parsed is not None, "run 15's reviewer answer was thrown away"
+        assert parsed["verdict"] == "REVISE"
+        assert parsed["source"] == "markdown_template"
+        assert len(parsed["feedback_items"]) == 2
+        first, second = parsed["feedback_items"]
+        assert "test_req_020" in first and "<= 5" in first and "```python" in first
+        assert "test_req_070" in second and "== 1" in second
+
+    def test_the_rationale_is_the_summary(self):
+        parsed = parse_markdown_review_spec(RUN15)
+        assert parsed is not None
+        assert parsed["rationale"].startswith("The revised spec correctly implements")
+        assert "## Verdict" not in parsed["rationale"]
+
+    def test_the_items_carry_the_spans_the_revision_lock_needs(self):
+        parsed = parse_markdown_review_spec(RUN15)
+        assert parsed is not None
+        joined = "\n".join(parsed["feedback_items"])
+        assert "`tests/integration/test_windows_collector.py`" in joined
+        assert "`test_req_020`" in joined
+        assert "`test_req_070`" in joined
+
+    def test_an_approved_template_has_no_items(self):
+        parsed = parse_markdown_review_spec(APPROVED_SPEC)
+        assert parsed is not None
+        assert parsed["verdict"] == "APPROVED"
+        assert parsed["feedback_items"] == []
+        assert parsed["rationale"] == "The spec is concrete and every test is executable."
+
+
+class TestTheReaderDoesNotGuess:
+    def test_no_checked_verdict_is_not_read(self):
+        assert parse_markdown_review_spec(RUN15.replace("[X] **REVISE**", "[ ] **REVISE**")) is None
+
+    def test_two_checked_verdicts_are_not_read(self):
+        assert parse_markdown_review_spec(RUN15.replace("[ ] **APPROVED**", "[X] **APPROVED**")) is None
+
+    @pytest.mark.parametrize("raw", ["", "prose", json.dumps({"verdict": "APPROVED"})])
+    def test_nothing_template_shaped_is_none(self, raw):
+        assert parse_markdown_review_spec(raw) is None
+        assert parse_markdown_verdict(raw) is None
+
+
+class TestTheTestPlanTemplate:
+    def test_blocked_with_required_changes(self):
+        parsed = parse_markdown_verdict(PLAN_TEMPLATE)
+        assert parsed is not None
+        assert parsed["verdict"] == "BLOCKED"
+        assert parsed["source"] == "markdown_template"
+        assert len(parsed["suggestions"]) == 2
+        assert parsed["suggestions"][0].startswith("T030")
+
+    def test_approved(self):
+        text = PLAN_TEMPLATE.replace("[ ] **APPROVED**", "[X] **APPROVED**").replace(
+            "[X] **BLOCKED**", "[ ] **BLOCKED**"
+        )
+        parsed = parse_markdown_verdict(text)
+        assert parsed is not None
+        assert parsed["verdict"] == "APPROVED"
+
+
+class _Scripted:
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.calls: list[tuple[str, str]] = []
+
+    def invoke(self, system, prompt, **_kwargs):
+        self.calls.append((system, prompt))
+        return SimpleNamespace(success=True, response=self.answers.pop(0), error_message=None)
+
+
+JSON_ANSWER = json.dumps({
+    "verdict": "APPROVED", "rationale": "fine", "feedback_items": [],
+})
+
+
+class TestTheHelperAsksAtMostTwice:
+    def test_json_first_time_is_one_call(self):
+        provider = _Scripted([JSON_ANSWER])
+        result, error = _invoke_reviewer_with_spec_schema(provider, "spec", "system")
+        assert error == "" and result is not None and result["verdict"] == "APPROVED"
+        assert len(provider.calls) == 1
+
+    def test_the_template_first_time_is_one_call(self, capsys):
+        provider = _Scripted([RUN15])
+        result, error = _invoke_reviewer_with_spec_schema(provider, "spec", "system")
+        assert error == "" and result is not None and result["verdict"] == "REVISE"
+        assert len(provider.calls) == 1
+        assert "own output template" in capsys.readouterr().out
+
+    def test_garbage_then_json_is_two_calls_naming_the_defect(self):
+        provider = _Scripted(["I would rather not.", JSON_ANSWER])
+        result, error = _invoke_reviewer_with_spec_schema(provider, "spec", "system")
+        assert error == "" and result is not None and result["verdict"] == "APPROVED"
+        assert len(provider.calls) == 2
+        assert "ONLY that JSON object" in provider.calls[1][0]
+
+    def test_garbage_then_template_is_read(self):
+        provider = _Scripted(["nothing", RUN15])
+        result, error = _invoke_reviewer_with_spec_schema(provider, "spec", "system")
+        assert error == "" and result is not None and result["verdict"] == "REVISE"
+        assert len(provider.calls) == 2
+
+    def test_garbage_twice_is_the_error_and_never_a_third_call(self):
+        provider = _Scripted(["nothing", "still nothing"])
+        result, error = _invoke_reviewer_with_spec_schema(provider, "spec", "system")
+        assert result is None
+        assert "unreadable twice" in error
+        assert len(provider.calls) == 2
+        assert provider.answers == []


### PR DESCRIPTION
Closes #2837

## Run 15 died on a verdict that named run 11's defect on round 1

Run 15 on boostgauge #4 (`run-issue4-025552`, 2026-09-05 02:55) cleared the requirements gate, the design draft, the design review (read from its template by #2835 — APPROVED), opened LLD PR #435, and cleared spec completeness on the third revision. Then the spec reviewer answered in the format `review_spec.py` itself demands — `_get_output_format()` says *"You MUST structure your review as follows"* and prints Summary / Blocking Issues / High Priority Issues / Suggestions / Verdict with *"Mark EXACTLY ONE verdict checkbox with [X]"* — and `parse_structured_review_spec` refused it for not being JSON. The run halted at 03:21. The answer (the fixture) marks `[X] **REVISE**`, reports no blocking issues, and lists two high-priority ones: the ±5 / 5 % tolerances in `test_req_020` against the body's ±1 / 1 % — run 11's four-round oscillation, caught on round 1 — and `>= 1` where T070 says `== 1`. The transport had appended #1843's JSON-only directive; same contradiction as #2835, one stage later.

## The templates are read as our own format

Standard 0028 §3 permits a deterministic walk of our own markdown format. `verdict_schema.py` gains:

- `parse_markdown_review_spec`: the single checked box under `## Verdict` (APPROVED / REVISE / BLOCKED, `REVIEW_SPEC_SCHEMA`'s enum); `feedback_items` as the numbered or bulleted entries under `## Blocking Issues` and `## High Priority Issues`, each carrying its continuation lines and code fences so the revision lock still sees the cited names and spans (#2716), minus the "No … found" placeholders; `rationale` from `## Summary`. None without exactly one checked verdict.
- `parse_markdown_verdict`: the same for the test-plan reviewer's template (`## Coverage Analysis` … `## Verdict` … `## Required Changes`), returning the shape `parse_structured_verdict` returns.
- `_checked_verdict` takes its allowed set; `_single_checked_verdict` and `_template_entries` are shared.

`_invoke_reviewer_with_spec_schema`: JSON first; then the template; then **one** re-ask whose system prompt names the defect; then the template again; then `(None, error)` as today. Two calls at most. `review_test_plan.py`, the third strict parser and the next one a roll would reach, reads its template when the JSON parse returns None, so the implementation stage cannot die the same way tomorrow.

## Tests

`tests/unit/test_spec_review_reads_template.py`, 16 tests. Run 15's answer reads as `REVISE` with two items that carry `test_req_020`, `<= 5`, the ` ```python ` fence, `test_req_070` and `== 1`, and the file path in backticks; the rationale is the Summary and not the whole text. An APPROVED spec template has no items. No checked box, two checked boxes, and nothing template-shaped are None for both readers. The test-plan template reads BLOCKED with two required changes, and APPROVED when the other box is marked. The helper: JSON first time is one call; the template first time is one call; garbage then JSON is two calls and the second names the defect; garbage then the template is read; garbage twice is the error after exactly two calls.

With #2835's suite and the fail-open gate: 83 passed. The second handler is declared (`# fail-open: not open` — it returns the rejection for the caller to halt on, as the first always did), and the denominator follows the new sites. Ruff clean.

## Not changed

The three prompts still hand out markdown templates while the transport demands JSON; which shape wins is the prompt ruling already named on #2835. Tonight every reviewer's template is readable.
