### PR TITLE
fix: api_symbols_exist reads a spec-defined subclass's bases, so a method it inherits from the standard library is the library's to be right about (Closes #2839)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -19,6 +19,7 @@ This node populates:
 """
 
 import ast
+import importlib
 import json
 import re
 import subprocess
@@ -2680,6 +2681,11 @@ class _CallSite(NamedTuple):
     #: attribute. None when the chain bottoms out in a call, subscript, or
     #: literal rather than a name.
     root: str | None
+    #: The spec-defined class whose body this call sits in, when the receiver
+    #: is ``self`` or ``cls`` (#2839). ``self.generic_visit(node)`` inside
+    #: ``class V(ast.NodeVisitor)`` is judged against V's surface, and V's
+    #: surface includes what it inherits.
+    owner: str | None = None
 
 
 class _FenceFacts(NamedTuple):
@@ -2714,6 +2720,16 @@ class _FenceFacts(NamedTuple):
     # wrong about. Only declared annotations are read; an unannotated name
     # records nothing and stays judged.
     annotated: tuple[tuple[str, str], ...] = ()
+    # (class name, base as written) for every base of every class the spec
+    # defines (#2839). `class UNICODE_STRING(ctypes.Structure)` records
+    # ("UNICODE_STRING", "ctypes.Structure"): the class's surface includes
+    # what it inherits, and `from_buffer_copy` is the standard library's to be
+    # right or wrong about, not the target repo's.
+    bases: tuple[tuple[str, str], ...] = ()
+    # (bound name, dotted module path it came from) for imports (#2839), so a
+    # bare base name resolves: `from ctypes import Structure` records
+    # ("Structure", "ctypes.Structure").
+    import_modules: tuple[tuple[str, str], ...] = ()
 
 
 class _FenceParseFailure(NamedTuple):
@@ -2886,12 +2902,20 @@ class _FenceVisitor(ast.NodeVisitor):
         self.classes: set[str] = set()
         self.opaque: set[str] = set()
         self.annotated: list[tuple[str, str]] = []
+        self.bases: list[tuple[str, str]] = []
+        self.import_modules: dict[str, str] = {}
+        self._class_stack: list[str] = []
 
     # ---- imports: receivers the target repo has no authority over (#1948) ----
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             self.imported.add(alias.asname or alias.name.split(".")[0])
+            # #2839: `import ctypes as c` binds c to ctypes; a dotted import
+            # binds its top name to itself.
+            self.import_modules[alias.asname or alias.name.split(".")[0]] = (
+                alias.name if alias.asname else alias.name.split(".")[0]
+            )
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -2900,6 +2924,10 @@ class _FenceVisitor(ast.NodeVisitor):
         for alias in node.names:
             if alias.name != "*":
                 self.imported.add(alias.asname or alias.name)
+                if node.module:
+                    self.import_modules[alias.asname or alias.name] = (
+                        f"{node.module}.{alias.name}"
+                    )
         self.generic_visit(node)
 
     # ---- definitions the spec itself supplies ----
@@ -2999,7 +3027,13 @@ class _FenceVisitor(ast.NodeVisitor):
         # annotation — `Gauge()` is a Gauge. Recorded separately from `defined`,
         # which mixes classes, functions and self-attributes.
         self.classes.add(node.name)
+        # #2839: the bases, as written, so the class's inherited surface can be
+        # resolved once every fence has been read.
+        for base in node.bases:
+            self.bases.append((node.name, ast.unparse(base)))
+        self._class_stack.append(node.name)
         self.generic_visit(node)
+        self._class_stack.pop()
 
     # ---- bindings: what each name actually holds ----
 
@@ -3105,12 +3139,23 @@ class _FenceVisitor(ast.NodeVisitor):
         if isinstance(node.func, ast.Attribute):
             receiver = _receiver_key(node.func.value)
             if receiver is not None:
+                # #2839: `self.x()` / `cls.x()` directly on the instance belongs
+                # to the enclosing class; `self.root.x()` keys on `root` and is
+                # somebody else's.
+                owner = None
+                if (
+                    self._class_stack
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in ("self", "cls")
+                ):
+                    owner = self._class_stack[-1]
                 self.calls.append(
                     _CallSite(
                         receiver,
                         node.func.attr,
                         self._site(node),
                         _leftmost_name(node.func.value),
+                        owner,
                     )
                 )
         self.generic_visit(node)
@@ -3143,7 +3188,84 @@ def _fence_facts_ast(block: str) -> _FenceFacts:
         classes=frozenset(visitor.classes),
         opaque=frozenset(visitor.opaque),
         annotated=tuple(visitor.annotated),
+        bases=tuple(visitor.bases),
+        import_modules=tuple(sorted(visitor.import_modules.items())),
     )
+
+
+def _resolve_stdlib_class(dotted: str) -> type | None:
+    """The standard-library class a dotted name denotes, or None (#2839).
+
+    Only standard-library modules are ever imported here: they are already
+    loaded or loadable without side effects, and ``sys.stdlib_module_names``
+    is a closed set. A third-party base (pydantic, Pillow) is never imported
+    and resolves to None, which the caller reads as "cannot say", not "wrong".
+    """
+    root, *rest = dotted.split(".")
+    if root not in _STDLIB_MODULE_NAMES:
+        return None
+    try:
+        obj: Any = importlib.import_module(root)
+        for part in rest:
+            obj = getattr(obj, part)
+    except (ImportError, AttributeError, ValueError):
+        # fail-open: a name the standard library does not have resolves to
+        # nothing, and nothing abstains -- unresolved is not hallucinated.
+        return None
+    return obj if isinstance(obj, type) else None
+
+
+def _inherited_surfaces(
+    class_bases: dict[str, list[str]],
+    import_modules: dict[str, str],
+    spec_classes: set[str],
+) -> dict[str, set[str] | None]:
+    """What each spec-defined class inherits from bases the target repo does
+    not own (#2839).
+
+    For every class: an empty set when its bases are all its own (spec- or
+    repo-defined) -- judged exactly as before; the union of ``dir()`` over
+    every base that resolves to a standard-library class; or None when some
+    base is a foreign import the checker cannot resolve, in which case methods
+    on the class abstain. Spec-defined bases contribute their own surface, to
+    a fixed point, so ``class B(A)`` with ``class A(ast.NodeVisitor)`` inherits
+    the visitor's methods too.
+    """
+    surfaces: dict[str, set[str] | None] = {}
+
+    def surface_of(cls: str, seen: frozenset[str]) -> set[str] | None:
+        if cls in surfaces:
+            return surfaces[cls]
+        result: set[str] | None = set()
+        for base in class_bases.get(cls, []):
+            root = base.split(".", 1)[0]
+            if root in spec_classes:
+                if root in seen:
+                    continue
+                inherited = surface_of(root, seen | {cls})
+                if inherited is None:
+                    result = None
+                    break
+                result |= inherited
+                continue
+            dotted = base
+            if root in import_modules:
+                dotted = import_modules[root] + base[len(root):]
+            resolved = _resolve_stdlib_class(dotted)
+            if resolved is None:
+                result = None
+                break
+            # The class's own attributes, plus its metaclass's: ctypes puts
+            # `from_buffer_copy` on `_ctypes.PyCStructType`, so it answers to
+            # `hasattr(ctypes.Structure, ...)` but is absent from `dir()` of
+            # the class. Run 15's exhibit was exactly that call.
+            result |= set(dir(resolved)) | set(dir(type(resolved)))
+        surfaces[cls] = result
+        return result
+
+    for cls in class_bases:
+        surface_of(cls, frozenset())
+    return surfaces
 
 
 def _scan_fences(text: str) -> _ScanResult:
@@ -3363,6 +3485,24 @@ def _flag_calls(
                 unresolved |= bound
                 changed = True
 
+    # #2839: a spec-defined class's surface includes its bases'. Resolve what
+    # each class inherits from bases the target repo does not own, and which
+    # bound names hold an instance of which class.
+    class_bases: dict[str, list[str]] = {}
+    import_modules: dict[str, str] = {}
+    for fence in facts:
+        for cls, base in fence.bases:
+            class_bases.setdefault(cls, []).append(base)
+        import_modules.update(dict(fence.import_modules))
+    inherited = _inherited_surfaces(class_bases, import_modules, spec_classes)
+    instance_class: dict[str, str] = {}
+    for bound, source in assignments:
+        if len(source) == 1 and len(bound) == 1:
+            (src,) = source
+            if src in spec_classes:
+                (name,) = bound
+                instance_class[name] = src
+
     flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
     for fence in facts:
         for call in fence.calls:
@@ -3398,6 +3538,18 @@ def _flag_calls(
                 continue
             if call.method in symbol_set or call.method in spec_defined:
                 continue
+            # #2839: the receiver is a spec-defined class -- the class itself,
+            # an instance bound from its constructor, or `self` in its body --
+            # and the method is one the class inherits from a standard-library
+            # base, or the class has a foreign base the checker cannot resolve.
+            owner = call.owner or (
+                call.receiver if call.receiver in spec_classes
+                else instance_class.get(call.receiver)
+            )
+            if owner is not None and owner in inherited:
+                surface = inherited[owner]
+                if surface is None or call.method in surface:
+                    continue
             # #2526: a method every Python object of a builtin type carries is
             # never a hallucinated PROJECT API, whoever the receiver is.
             # `str.isupper` on an AST walk killed a run that had passed the

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8917,
-    "findings_total": 534
+    "sites_examined": 8937,
+    "findings_total": 535
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_inherited_surface.py
+++ b/tests/unit/test_inherited_surface.py
@@ -1,0 +1,137 @@
+"""#2839: a spec-defined subclass's surface includes what it inherits.
+
+Run 15 resumed (`run-issue4-040403`, 2026-09-05) spent a completeness
+iteration on `api_symbols_exist` flagging `UNICODE_STRING.from_buffer_copy`,
+`self.generic_visit(node)` and `visitor.visit(tree)` -- ctypes.Structure's
+classmethod and ast.NodeVisitor's methods, on classes the spec defined as
+their subclasses. The check recorded the classes by name and never read
+their bases, so their instances were judged against the target repo's
+symbols, where nothing inherited from the standard library can be found.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    detect_unknown_method_calls,
+)
+
+# The target repo's gathered symbols: nothing from ctypes or ast is in here.
+TARGET = {"WindowsCollector", "collect", "start", "stop", "Gauge", "render"}
+
+
+def _spec(code: str) -> str:
+    return f"## 6. Implementation\n\n```python\n{code}\n```\n"
+
+
+class TestRun15sThreeCalls:
+    def test_a_ctypes_structure_subclass_inherits_from_buffer_copy(self):
+        spec = _spec(
+            "import ctypes\n"
+            "class UNICODE_STRING(ctypes.Structure):\n"
+            "    _fields_ = [('Length', ctypes.c_ushort)]\n"
+            "us = UNICODE_STRING.from_buffer_copy(buffer, offset + 56)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+    def test_a_node_visitor_subclass_inherits_visit_and_generic_visit(self):
+        spec = _spec(
+            "import ast\n"
+            "class SweepVisitor(ast.NodeVisitor):\n"
+            "    def visit_Call(self, node):\n"
+            "        self.generic_visit(node)\n"
+            "visitor = SweepVisitor()\n"
+            "visitor.visit(tree)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+    def test_a_bare_imported_base_resolves_through_its_import(self):
+        spec = _spec(
+            "from ctypes import Structure, c_ushort\n"
+            "class S(Structure):\n"
+            "    _fields_ = [('n', c_ushort)]\n"
+            "s = S.from_buffer_copy(b)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+    def test_an_aliased_module_resolves(self):
+        spec = _spec(
+            "import ctypes as c\n"
+            "class S(c.Structure):\n"
+            "    pass\n"
+            "S.from_buffer_copy(b)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+
+class TestWhatStaysFlagged:
+    def test_a_typo_on_the_inherited_name_is_still_flagged(self):
+        spec = _spec(
+            "import ctypes\n"
+            "class UNICODE_STRING(ctypes.Structure):\n"
+            "    pass\n"
+            "us = UNICODE_STRING.from_buffer_cpy(buffer, 56)\n"
+        )
+        assert set(detect_unknown_method_calls(spec, set(TARGET))) == {"from_buffer_cpy"}
+
+    def test_self_method_the_class_neither_defines_nor_inherits_is_flagged(self):
+        spec = _spec(
+            "import ast\n"
+            "class SweepVisitor(ast.NodeVisitor):\n"
+            "    def visit_Call(self, node):\n"
+            "        self.render_all(node)\n"
+            "        self.generic_visit(node)\n"
+        )
+        assert set(detect_unknown_method_calls(spec, set(TARGET))) == {"render_all"}
+
+    def test_a_class_with_no_foreign_base_is_judged_as_before(self):
+        """#1527's founding true positive: pydantic's method on a plain class."""
+        spec = _spec(
+            "class Gauge:\n"
+            "    def render(self):\n"
+            "        return 1\n"
+            "g = Gauge()\n"
+            "g.model_dump()\n"
+        )
+        assert set(detect_unknown_method_calls(spec, set(TARGET))) == {"model_dump"}
+
+    def test_self_call_inside_a_plain_class_is_judged_as_before(self):
+        spec = _spec(
+            "class Gauge:\n"
+            "    def render(self):\n"
+            "        return self.model_dump()\n"
+        )
+        assert set(detect_unknown_method_calls(spec, set(TARGET))) == {"model_dump"}
+
+
+class TestForeignBasesAbstain:
+    def test_a_third_party_base_the_checker_cannot_resolve_abstains(self):
+        spec = _spec(
+            "from pydantic import BaseModel\n"
+            "class Config(BaseModel):\n"
+            "    name: str\n"
+            "cfg = Config(name='x')\n"
+            "cfg.model_dump()\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+    def test_a_spec_defined_base_passes_its_inheritance_down(self):
+        spec = _spec(
+            "import ast\n"
+            "class Base(ast.NodeVisitor):\n"
+            "    pass\n"
+            "class Leaf(Base):\n"
+            "    def visit_Name(self, node):\n"
+            "        self.generic_visit(node)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}
+
+    def test_self_root_attribute_calls_are_not_the_classs(self):
+        """`self.root.x()` keys on `root`, whoever owns it -- unchanged by #2839."""
+        spec = _spec(
+            "import tkinter as tk\n"
+            "class App:\n"
+            "    def __init__(self):\n"
+            "        self.root = tk.Tk()\n"
+            "        self.root.attributes('-topmost', True)\n"
+        )
+        assert detect_unknown_method_calls(spec, set(TARGET)) == {}


### PR DESCRIPTION
Closes #2839

## A subclass's surface includes what it inherits

Run 15 resumed (`run-issue4-040403`, 2026-09-05 04:04) cleared three completeness complaints in one revision and then spent iteration 2 of 3 on `api_symbols_exist` flagging `UNICODE_STRING.from_buffer_copy(...)`, `self.generic_visit(node)` and `visitor.visit(tree)` as "possibly hallucinated APIs". All three are real: `from_buffer_copy` is `ctypes.Structure`'s classmethod and the two visitor methods are `ast.NodeVisitor`'s, on classes the spec defined as their subclasses. The check's fixed point (#2399, #2526, #2713) recorded each class by name and never read its bases, so instances and `self` stayed judged against the target repo's symbols, where nothing inherited from the standard library can be found. The drafter was told to verify or replace an API it had not invented.

## What changed

`_FenceVisitor` records every class's bases as written and every import's dotted source (`from ctypes import Structure` → `Structure` is `ctypes.Structure`; `import ctypes as c` → `c` is `ctypes`), and tags a `self.x()` / `cls.x()` call with the class whose body it sits in. `_inherited_surfaces` resolves, per spec-defined class: the union of `dir()` over every base that resolves to a standard-library class — plus the metaclass's `dir()`, because ctypes puts `from_buffer_copy` on `_ctypes.PyCStructType` where `dir(ctypes.Structure)` cannot see it — with spec-defined bases contributing their own surface to a fixed point; `None` when a base is a foreign import the checker cannot resolve (pydantic, Pillow), in which case methods on that class abstain — unresolved is not hallucinated. Only `sys.stdlib_module_names` modules are ever imported. A class whose bases are all its own is judged exactly as before.

In `_flag_calls`, a call whose receiver is a spec-defined class, an instance bound from its constructor, or `self` in its body is cleared when the method is on the inherited surface, or when the surface is unresolvable; otherwise it falls through to today's tests unchanged.

## Tests

`tests/unit/test_inherited_surface.py`, 11 tests: the three run-15 calls clear (dotted, bare-imported and aliased bases); a typo on the inherited name is still flagged; `self.render_all()` on the visitor subclass is still flagged; #1527's founding true positive — pydantic's method on a plain class — is still flagged, as instance and as `self`; a pydantic-based class abstains; a spec-defined base passes its inheritance down; `self.root.x()` keys on `root` as before. Neighbouring suites (AST symbol analysis, attribute and stdlib receivers, hallucination telemetry, and every completeness/spec-stage suite): all green. The one new `except` is declared for the fail-open audit (an unimportable standard-library name resolves to nothing, which abstains). Ruff clean.
