### PR TITLE
fix: the green loop's cap grants one more iteration to a loop that improved, up to a ceiling of ten (Closes #2841)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -705,6 +705,53 @@ def restore_best_on_failure(state: TestingWorkflowState) -> str:
     return description
 
 
+def _cap_grace(
+    state: dict,
+    iteration_count: int,
+    max_iterations: int,
+    passed_count: int,
+    coverage_achieved: float,
+) -> int | None:
+    """One more iteration past the cap when this one improved (#2841).
+
+    The base cap is a budget and stays one. But a loop that gains passing
+    tests every iteration is converging, not stagnating, and a fixed number
+    that ends it there is the coverage guard that killed run 9 wearing a
+    budget's clothes. So at the cap: if the iteration that just finished
+    passed more tests than the one before it -- or the same tests at higher
+    coverage -- the cap grows by one, up to ``GREEN_ITERATION_CEILING``. An
+    iteration that did not improve gets nothing, and the cap ends the loop
+    exactly as before.
+
+    Returns the new cap, or None when no grace applies. The caller writes the
+    new cap into state so the graph's routers, which read ``max_iterations``
+    from state, honour it too.
+    """
+    from assemblyzero.workflows.testing.state import GREEN_ITERATION_CEILING
+
+    if max_iterations >= GREEN_ITERATION_CEILING:
+        print(
+            f"    [N5] iteration cap {max_iterations} is the ceiling; no further "
+            f"grace (#2841)"
+        )
+        return None
+    previous_passed = int(state.get("previous_passed", -1) or -1)
+    previous_coverage = float(state.get("previous_coverage", -1.0) or -1.0)
+    improved = passed_count > previous_passed or (
+        passed_count == previous_passed and coverage_achieved > previous_coverage
+    )
+    if not improved:
+        return None
+    new_cap = max_iterations + 1
+    print(
+        f"    [N5] cap grace (#2841): iteration {iteration_count + 1} improved on "
+        f"the last ({previous_passed} -> {passed_count} passing, "
+        f"{previous_coverage:.1f}% -> {coverage_achieved:.1f}%); one more "
+        f"iteration, cap now {new_cap} of a ceiling of {GREEN_ITERATION_CEILING}"
+    )
+    return new_cap
+
+
 #: #2347: exception types that mean the TEST is wrong, not the code. Each one
 #: names a condition no implementation choice can satisfy on the host running
 #: it -- a platform-specific pathlib operation, a module that is not
@@ -2130,6 +2177,14 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
     # Check for failures
     if failed_count > 0 or error_count > 0:
+        # #2841: at the cap, an iteration that improved on the last earns one
+        # more, up to the ceiling. The grant travels in state (below).
+        if iteration_count + 1 >= max_iterations:
+            granted = _cap_grace(
+                state, iteration_count, max_iterations, passed_count, coverage_achieved
+            )
+            if granted is not None:
+                max_iterations = granted
         # Check if we've exhausted iterations
         if iteration_count + 1 >= max_iterations:
             print(f"    [ERROR] Max iterations ({max_iterations}) reached with {failed_count} failures")
@@ -2352,12 +2407,21 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "coverage_plateau_strikes": coverage_strikes,
             "freeze_tests": identity_stagnant,
         }
+        # #2841: a granted cap must reach the routers, which read it from state.
+        updates["max_iterations"] = max_iterations
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)
         return updates
 
     # Check coverage
     if coverage_achieved < coverage_target:
+        # #2841: the same grace for a loop still gaining coverage.
+        if iteration_count + 1 >= max_iterations:
+            granted = _cap_grace(
+                state, iteration_count, max_iterations, passed_count, coverage_achieved
+            )
+            if granted is not None:
+                max_iterations = granted
         # Check if we've exhausted iterations
         if iteration_count + 1 >= max_iterations:
             print(f"    [ERROR] Max iterations ({max_iterations}) reached with {coverage_achieved:.1f}% coverage")
@@ -2459,6 +2523,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "identity_plateau_strikes": 0,
             "coverage_plateau_strikes": coverage_strikes,
             "freeze_tests": False,
+            # #2841: a granted cap must reach the routers.
+            "max_iterations": max_iterations,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -28,6 +28,13 @@ from typing import Literal, TypedDict
 #: reported passed while holding 31 passed / 1 failed.
 DEFAULT_MAX_ITERATIONS = 5
 
+#: #2841: the hard ceiling the green loop may be granted up to, one iteration
+#: at a time, while each iteration improves on the last (more tests passing,
+#: or the same tests at higher coverage). The base cap above stays the budget;
+#: this is how far a loop that is still converging may be carried past it.
+#: Run 15 climbed 29, 35, 45, 47 passing and met the base cap at 47 of 51.
+GREEN_ITERATION_CEILING = 10
+
 
 class HumanDecision(str, Enum):
     """User choices at human gate nodes."""

--- a/assemblyzero/workflows/testing/step_budget.py
+++ b/assemblyzero/workflows/testing/step_budget.py
@@ -78,6 +78,13 @@ def recursion_limit(max_iterations: int | None = None) -> int:
     # N5 -> N4 -> N4b -> N5, once per green iteration.
     total += iterations * 3
 
+    # #2841: the iterations the cap may be granted past the base, one per
+    # improving iteration, up to the ceiling. Budgeted whether or not they are
+    # granted, so a granted iteration never runs into the recursion limit.
+    from assemblyzero.workflows.testing.state import GREEN_ITERATION_CEILING
+
+    total += max(0, GREEN_ITERATION_CEILING - DEFAULT_MAX_ITERATIONS) * 3
+
     # N5 -> N4c -> N5, once per coverage-augment attempt.
     total += MAX_COVERAGE_AUGMENT_ATTEMPTS * 2
 

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8937,
+    "sites_examined": 8946,
     "findings_total": 535
   },
   "undeclared": [

--- a/tests/unit/test_green_cap_grace.py
+++ b/tests/unit/test_green_cap_grace.py
@@ -1,0 +1,119 @@
+"""#2841: the green loop's cap grants one more iteration to a loop that improved.
+
+Run 15 resumed (`run-issue4-040403`, 2026-09-05) climbed 29, 35, 45, 47
+passing across four green iterations and met the base cap of 5 with four
+tests still failing. A fixed cap ending a converging loop is the coverage
+guard that killed run 9 wearing a budget's clothes. The base cap stays; an
+iteration that improved on the last earns one more, up to a ceiling of 10.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _cap_grace,
+    verify_green_phase,
+)
+from assemblyzero.workflows.testing.state import (
+    DEFAULT_MAX_ITERATIONS,
+    GREEN_ITERATION_CEILING,
+)
+from assemblyzero.workflows.testing.step_budget import recursion_limit
+
+
+class TestTheGraceRule:
+    def test_more_tests_passing_at_the_cap_earns_one_more(self, capsys):
+        state = {"previous_passed": 45, "previous_coverage": 92.0}
+        assert _cap_grace(state, 4, 5, 47, 93.0) == 6
+        out = capsys.readouterr().out
+        assert "cap grace" in out and "45 -> 47" in out and "ceiling of 10" in out
+
+    def test_same_tests_at_higher_coverage_earns_one_more(self):
+        state = {"previous_passed": 47, "previous_coverage": 92.0}
+        assert _cap_grace(state, 4, 5, 47, 93.0) == 6
+
+    def test_no_improvement_earns_nothing(self):
+        state = {"previous_passed": 47, "previous_coverage": 93.0}
+        assert _cap_grace(state, 4, 5, 47, 93.0) is None
+        assert _cap_grace(state, 4, 5, 46, 99.0) is None
+
+    def test_the_ceiling_is_the_ceiling(self, capsys):
+        state = {"previous_passed": 1, "previous_coverage": 1.0}
+        assert _cap_grace(state, 9, GREEN_ITERATION_CEILING, 50, 99.0) is None
+        assert "ceiling" in capsys.readouterr().out
+
+    def test_the_first_iteration_counts_as_improvement(self):
+        assert _cap_grace({}, 4, 5, 1, 1.0) == 6
+
+
+def _state(**overrides):
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 4,
+        "iteration_count": 4,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": 92.0,
+        "previous_passed": 45,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(returncode, passed, failed, coverage):
+    return {
+        "returncode": returncode,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": failed, "errors": 0, "coverage": coverage},
+    }
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.check_circuit_breaker", return_value=(False, ""))
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+class TestTheNodeAtTheCap:
+    def test_run_15s_fifth_iteration_is_granted_a_sixth(self, mock_pytest, _log, _cb):
+        """47 of 51 at iteration 5 of 5, up from 45: one more, cap now 6."""
+        mock_pytest.return_value = _pytest(1, passed=47, failed=4, coverage=93.0)
+        result = verify_green_phase(_state())
+        assert result["error_message"] == ""
+        assert result["next_node"] != "end"
+        assert result["max_iterations"] == DEFAULT_MAX_ITERATIONS + 1
+        assert result["iteration_count"] == 5
+
+    def test_a_fifth_iteration_that_did_not_improve_halts_as_before(self, mock_pytest, _log, _cb):
+        mock_pytest.return_value = _pytest(1, passed=45, failed=6, coverage=92.0)
+        result = verify_green_phase(_state())
+        assert result["next_node"] == "end"
+        assert "Max iterations" in result["error_message"] or "iterations" in result["error_message"]
+        assert "max_iterations" not in result
+
+    def test_the_ceiling_halts_even_an_improving_loop(self, mock_pytest, _log, _cb):
+        mock_pytest.return_value = _pytest(1, passed=50, failed=1, coverage=94.0)
+        result = verify_green_phase(_state(
+            iteration_count=GREEN_ITERATION_CEILING - 1,
+            max_iterations=GREEN_ITERATION_CEILING,
+        ))
+        assert result["next_node"] == "end"
+        assert "iterations" in result["error_message"]
+
+
+
+class TestTheStepBudgetCoversTheCeiling:
+    def test_headroom_for_every_grantable_iteration(self):
+        """Five more iterations of three super-steps each are budgeted whether
+        or not they are granted, so a granted iteration never meets the
+        recursion limit."""
+        with_grace = recursion_limit(max_iterations=DEFAULT_MAX_ITERATIONS)
+        assert with_grace >= GREEN_ITERATION_CEILING * 3
+        # The grace term is constant: asking for the ceiling outright adds the
+        # five iterations again, which is the budget being conservative, never
+        # short.
+        assert recursion_limit(max_iterations=GREEN_ITERATION_CEILING) > with_grace

--- a/tests/unit/test_impl_step_budget.py
+++ b/tests/unit/test_impl_step_budget.py
@@ -85,6 +85,10 @@ class TestTheBudgetIsDerived:
         from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
             MAX_SCAFFOLD_ATTEMPTS,
         )
+        from assemblyzero.workflows.testing.state import (
+            DEFAULT_MAX_ITERATIONS,
+            GREEN_ITERATION_CEILING,
+        )
 
         expected = (
             TOTAL_STEPS
@@ -92,6 +96,9 @@ class TestTheBudgetIsDerived:
             + (MAX_SCAFFOLD_ATTEMPTS + 1) * 3
             + MAX_COMPLETENESS_ITERATIONS * 2
             + 5 * 3
+            # #2841: the iterations the cap may grant past the base, budgeted
+            # whether or not they are granted.
+            + (GREEN_ITERATION_CEILING - DEFAULT_MAX_ITERATIONS) * 3
             + MAX_COVERAGE_AUGMENT_ATTEMPTS * 2
             + 5 * 4
             + HEADROOM_STEPS

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -150,18 +150,35 @@ class TestGenuineStagnationIsStillDetected:
         assert result["coverage_plateau_strikes"] == 1
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_max_iterations_still_wins_over_test_progress(self, mock_pytest):
-        """The iteration budget is the outer bound; improving tests must not
-        let a run spend past it."""
+    def test_the_base_cap_grants_one_more_to_test_progress(self, mock_pytest):
+        """#2841: at the base cap, an iteration that passed more tests than the
+        last earns one more iteration; the cap in state grows by one."""
         mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
         result = verify_green_phase(
             _state(previous_passed=14, previous_coverage=94.0, iteration_count=4,
                    max_iterations=5, previous_green_failures=["test_decay"])
         )
 
+        assert result["next_node"] != "end", result.get("error_message")
+        assert result["max_iterations"] == 6
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_ceiling_still_wins_over_test_progress(self, mock_pytest):
+        """The ceiling is the outer bound; improving tests must not let a run
+        spend past it (#2841)."""
+        from assemblyzero.workflows.testing.state import GREEN_ITERATION_CEILING
+
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=14, previous_coverage=94.0,
+                   iteration_count=GREEN_ITERATION_CEILING - 1,
+                   max_iterations=GREEN_ITERATION_CEILING,
+                   previous_green_failures=["test_decay"])
+        )
+
         assert result["next_node"] == "end"
         assert "Max iterations" in result.get("error_message", "") or \
-               "after 5 iterations" in result.get("error_message", "")
+               f"after {GREEN_ITERATION_CEILING} iterations" in result.get("error_message", "")
 
 
 class TestReachingTargetIsUnaffected:


### PR DESCRIPTION
Closes #2841

## A fixed cap was about to end a converging loop

Run 15 resumed (`run-issue4-040403`, 2026-09-05) reached the implementation stage's green loop and climbed on every iteration — 29 of 39 passing at 96 %, 35 of 39 at 93 %, 45 of 52 at 92 %, 47 of 51 at 93 % — with the base cap of 5 one iteration away. `DEFAULT_MAX_ITERATIONS` ends the loop after the fifth run of the suite whatever the trend. Five was sized before any run had reached this loop. A loop gaining passing tests every iteration is converging, and a number that ends it there is the coverage guard that killed run 9 (#2723) wearing a budget's clothes.

## The cap grants one more iteration to a loop that improved

`_cap_grace` in `verify_phases.py`: at the cap, if the iteration that just finished passed more tests than the one before it — or the same tests at higher coverage — the cap grows by one, up to `GREEN_ITERATION_CEILING = 10` (`state.py`). An iteration that did not improve gets nothing, and the cap ends the loop exactly as before, bundle and all. The same shape the spec review loop already has: base 3, ceiling 9, rounds granted only on progress.

Both cap sites in `verify_green_phase` — tests still failing, and all passing but under-covered — consult it, and both write the granted cap into state, because the graph's two routers read `max_iterations` from state and must honour the grant. `step_budget.py` budgets the five grantable iterations whether or not they are granted, so a granted one never meets the recursion limit #2790 sized; `test_impl_step_budget`'s derivation gains the same term.

No new halt site: the cap's existing halt stays, and the ratchet is unchanged (`test_gate_registry` passes).

## Tests

`tests/unit/test_green_cap_grace.py`: the rule — more tests passing earns one more and the log names the grant; same tests at higher coverage earns one more; no improvement earns nothing; the ceiling is the ceiling; a first iteration counts as improvement. The node at the cap, with the suite runner mocked: run 15's shape (47 of 51 at iteration 5 of 5, up from 45) continues with the cap at 6; a fifth iteration that did not improve halts as before with no grant in state; an improving loop at the ceiling still halts. The step budget carries the headroom. Green-loop suites (stagnation, both branches, loop contract), routing policy, gate registry, both step budgets and the fail-open gate: all green; the fail-open denominator follows the new sites. Ruff clean.
