### PR TITLE
fix: the per-file wall clock is an hour — a backstop for silence must not end a call that is still producing output (Closes #2843)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
@@ -30,8 +30,15 @@ CLI_TIMEOUT = 600  # 10 minutes base (historical; no longer the floor)
 # floor now starts where the cap was, and both are environment-overridable so
 # that the next time the distribution outgrows a constant, the remedy is a
 # variable rather than a merge.
-FILE_TIMEOUT_FLOOR = 1200
-FILE_TIMEOUT_CAP = 1200
+#
+# #2843: at 1200 this "backstop for silence" killed two calls in one green
+# iteration of boostgauge run 15 that were still streaming (1,674 and 1,804
+# events), each costing the twenty minutes spent plus a whole-file
+# regeneration. The idle timeout is the guard against a dead call; a call
+# still producing output is not stuck, and the wall clock protects nothing
+# the cost budget does not. An hour is the outer bound for one file.
+FILE_TIMEOUT_FLOOR = 3600
+FILE_TIMEOUT_CAP = 3600
 
 #: Override names. Values are whole seconds. A missing, unparseable, or
 #: non-positive value falls back to the default rather than failing the call:

--- a/tests/unit/test_file_timeout_backstop.py
+++ b/tests/unit/test_file_timeout_backstop.py
@@ -1,0 +1,44 @@
+"""#2843: the per-file wall clock is a backstop, not a limit on productive output.
+
+Run 15 (2026-09-05) lost two streaming calls in one green iteration to the
+1200 s wall clock -- "timed out after 1200s while still producing output
+(1804 events)". The idle timeout kills a dead call; the wall clock's job is
+the outer bound, and it now sits at an hour.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+    ENV_TIMEOUT_CAP,
+    ENV_TIMEOUT_FLOOR,
+    FILE_TIMEOUT_CAP,
+    FILE_TIMEOUT_FLOOR,
+    calculate_timeout,
+)
+
+
+def test_the_default_is_an_hour(monkeypatch):
+    monkeypatch.delenv(ENV_TIMEOUT_FLOOR, raising=False)
+    monkeypatch.delenv(ENV_TIMEOUT_CAP, raising=False)
+    assert FILE_TIMEOUT_FLOOR == 3600
+    assert FILE_TIMEOUT_CAP == 3600
+    assert calculate_timeout("tiny") == 3600
+    assert calculate_timeout("x" * 500_000) == 3600
+
+
+def test_the_two_run_15_calls_would_have_been_allowed_to_finish(monkeypatch):
+    """Both were killed at 1200 s while streaming; neither reaches the new bound."""
+    monkeypatch.delenv(ENV_TIMEOUT_FLOOR, raising=False)
+    monkeypatch.delenv(ENV_TIMEOUT_CAP, raising=False)
+    for killed_at in (1200, 1200):
+        assert killed_at < calculate_timeout("a green-iteration edit prompt")
+
+
+def test_the_overrides_still_apply(monkeypatch):
+    monkeypatch.setenv(ENV_TIMEOUT_FLOOR, "100")
+    monkeypatch.setenv(ENV_TIMEOUT_CAP, "100")
+    assert calculate_timeout("tiny") == 100
+    monkeypatch.setenv(ENV_TIMEOUT_FLOOR, "7200")
+    monkeypatch.delenv(ENV_TIMEOUT_CAP, raising=False)
+    # A cap below an operator's floor never undoes the floor.
+    assert calculate_timeout("tiny") == 7200

--- a/tests/unit/test_file_timeout_backstop.py
+++ b/tests/unit/test_file_timeout_backstop.py
@@ -13,7 +13,7 @@ from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
     ENV_TIMEOUT_FLOOR,
     FILE_TIMEOUT_CAP,
     FILE_TIMEOUT_FLOOR,
-    calculate_timeout,
+    compute_dynamic_timeout as calculate_timeout,
 )
 
 

--- a/tests/unit/test_llm_idle_timeout.py
+++ b/tests/unit/test_llm_idle_timeout.py
@@ -196,9 +196,10 @@ def test_the_wall_backstop_still_exists_for_a_call_that_streams_forever():
 
 
 def test_the_floor_no_longer_sits_at_600():
-    """#2405: 602s killed boostgauge #1 five times. The floor moved past it."""
-    assert FILE_TIMEOUT_FLOOR == 1200
-    assert compute_dynamic_timeout("x" * 2500) == 1200
+    """#2405: 602s killed boostgauge #1 five times. The floor moved past it.
+    #2843: and past 1200, which killed two streaming calls on run 15."""
+    assert FILE_TIMEOUT_FLOOR == 3600
+    assert compute_dynamic_timeout("x" * 2500) == 3600
 
 
 def test_the_scaling_never_reached_the_cap_which_is_why_the_floor_had_to_move():
@@ -208,13 +209,16 @@ def test_the_scaling_never_reached_the_cap_which_is_why_the_floor_had_to_move():
     Reaching the old 1200 cap from a 600 floor needed 600,000 characters.
     """
     old_floor = 600
+    old_cap = 1200
     realistic_prompt_chars = 2500
     assert old_floor + realistic_prompt_chars // 1000 == 602
-    assert (FILE_TIMEOUT_CAP - old_floor) * 1000 == 600_000
+    assert (old_cap - old_floor) * 1000 == 600_000
+    assert FILE_TIMEOUT_CAP >= old_cap
 
 
 def test_the_floor_is_overridable_by_environment(monkeypatch):
     monkeypatch.setenv(ENV_TIMEOUT_FLOOR, "1800")
+    monkeypatch.setenv(ENV_TIMEOUT_CAP, "1800")
     assert compute_dynamic_timeout("x" * 2500) == 1800
 
 
@@ -229,7 +233,7 @@ def test_a_bad_override_falls_back_rather_than_failing_the_call(monkeypatch, bad
     """An operator setting this is rescuing a stalled run. A typo must not
     convert a slow call into a dead one."""
     monkeypatch.setenv(ENV_TIMEOUT_FLOOR, bad)
-    assert compute_dynamic_timeout("x" * 2500) == 1200
+    assert compute_dynamic_timeout("x" * 2500) == FILE_TIMEOUT_FLOOR
 
 
 def test_the_idle_threshold_is_overridable_too(monkeypatch):


### PR DESCRIPTION
Closes #2843

## A backstop for silence that fires on output

Run 15 resumed (`run-issue4-040403`, 2026-09-05), green iteration 5, twice within the one iteration that was a revision away from finishing the loop: `claude -p timed out after 1200s while still producing output (1674 events)` and then `(1804 events)`, each falling back to a whole-file regeneration. `calculate_timeout`'s own docstring (#2405) calls the wall clock "the outer wall-clock backstop, not the operative limit" and says reaching it "means the process stayed silent for the whole window". It was reached by a process that produced 1,804 events. The idle timeout is the guard against a dead call; a call still streaming is not stuck, and the wall clock at 1200 protected nothing the cost budget does not — it ended the call at the moment its output was largest, and told an absent operator to set an environment variable.

## What changed

`FILE_TIMEOUT_FLOOR` and `FILE_TIMEOUT_CAP` rise from 1200 to 3600 — an hour is the outer bound for one file's generation. The idle timeout and the environment overrides are untouched.

## Tests

`tests/unit/test_file_timeout_backstop.py`: the default is an hour for a tiny prompt and a huge one; the two calls run 15 lost at 1200 s sit under the new bound; the overrides still apply and a cap below an operator's floor never undoes the floor. `test_implement_code_context.py` and `test_llm_idle_timeout.py`, which read the constants symbolically, pass unchanged.
