### PR TITLE
fix: a resume into the impl stage starts from the preserved attempt, not from zero (Closes #2845)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -14,6 +14,7 @@ from assemblyzero.utils.git import GitBranchError, current_branch
 from assemblyzero.utils.shell import run_command
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -32,6 +33,7 @@ from assemblyzero.workflows.orchestrator.state import (
     update_stage_result,
 )
 from assemblyzero.core.llm_provider import get_provider
+from assemblyzero.core.retry_mode import RESUMED
 from assemblyzero.core import settlement as settlement_mod
 
 import logging
@@ -1350,6 +1352,95 @@ def _classify_leftover_branch(
     )
 
 
+#: A graveyard branch holding one prior implementation attempt for one issue.
+#: Anchored on both ends so `issue-4` never matches `issue-41`'s graves, and
+#: so the hand-made names in a long-lived campaign repo -- `graveyard/arc1-issue-4`,
+#: `graveyard/run11-roll10-issue-4` -- are not mistaken for the machinery's own
+#: (#2845). The stamp is `_disposal_stamp()`'s, which sorts.
+_GRAVEYARD_ATTEMPT = re.compile(r"^graveyard/issue-(\d+)-(\d{8}T\d{6}Z)$")
+
+
+def _recoverable_attempt_branch(
+    target_repo: str, issue_number: int, base_branch: str,
+) -> tuple[str, int] | None:
+    """The newest preserved attempt for #issue worth resuming from, or None.
+
+    #2845: RESTORE removes the implementation worktree on every exit (#2005),
+    so `verify_phases._restore_best`'s snapshot of the best iteration dies
+    with it. What survives is the attempt branch, renamed under `graveyard/`
+    by the #2310 disposal discipline. On boostgauge run 15 that branch held
+    the whole 48-of-52-passing implementation -- eight files, 1,356 lines,
+    across a post-scaffold and five post-impl checkpoints -- and the resume
+    that followed carved a worktree from the base and implemented from zero,
+    repaying two and a half hours of paid work for nothing.
+
+    Two conditions, both measured, before an attempt is offered back:
+
+    * `base_branch` is an ANCESTOR of it. That is what proves the attempt was
+      cut from the base this run is rolling on. A grave from an earlier phase,
+      or from before the base moved, fails the test and is left alone --
+      resuming stale work is worse than an honest start from zero, so the
+      unprovable case falls through to the ordinary path.
+    * it carries commits the base does not. A grave with nothing unique has
+      nothing to give back; `dispose_pipeline_branches` should not have made
+      one, and if it did, it is not this function's to resurrect.
+
+    Every git failure resolves to None, so an unreadable repo keeps the
+    previous behaviour rather than inventing a new one.
+    """
+    if not base_branch:
+        return None
+
+    def _git(*args: str) -> subprocess.CompletedProcess:
+        cmd = ["git"]
+        if target_repo:
+            cmd += ["-C", target_repo]
+        return run_command(
+            [*cmd, *args], check=False, capture_output=True, text=True,
+        )
+
+    listed = _git(
+        "branch", "--list", "--format=%(refname:short)",
+        f"graveyard/issue-{issue_number}-*",
+    )
+    if listed.returncode != 0:
+        return None
+
+    candidates: list[tuple[str, str]] = []
+    for line in listed.stdout.splitlines():
+        branch = line.strip()
+        match = _GRAVEYARD_ATTEMPT.match(branch)
+        # `--list` globs, so `issue-4-*` also matches `issue-41-...`. The
+        # captured number is compared, never the glob's word.
+        if match and int(match.group(1)) == issue_number:
+            candidates.append((match.group(2), branch))
+
+    # Newest disposal first: the stamp is UTC and fixed-width, so it sorts.
+    for _stamp, branch in sorted(candidates, reverse=True):
+        if _git(
+            "merge-base", "--is-ancestor", base_branch, branch,
+        ).returncode != 0:
+            continue
+        counted = _git("rev-list", "--count", f"{base_branch}..{branch}")
+        if counted.returncode != 0:
+            continue
+        try:
+            unique = int(counted.stdout.strip())
+        except ValueError:
+            # fail-open: an unmeasurable candidate is skipped, and a run out
+            # of candidates starts the implementation from the base -- which
+            # is exactly what every resume did before #2845. The failure
+            # direction that matters here is the opposite one: resurrecting a
+            # grave whose ancestry could not be established would build on a
+            # tree the campaign has moved off, silently. Declining is visible
+            # in the log ("No preserved attempt ... is resumable") and costs
+            # only the rebuild that was the status quo.
+            continue
+        if unique > 0:
+            return branch, unique
+    return None
+
+
 def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute implementation workflow (TDD).
 
@@ -1366,6 +1457,10 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     assemblyzero_root = state.get("assemblyzero_root", "")
     worktree_path = worktree_path_for(issue_number, target_repo or None)
     branch_name = f"issue-{issue_number}"
+    # #2845: set only when this entry carved the worktree from a preserved
+    # attempt. Declared out here because a worktree that already exists skips
+    # the creation block entirely and still reaches the sub-workflow invoke.
+    recovered_branch = ""
 
     try:
         # Ensure the worktree exists, carved from the TARGET repo (Issue #1374).
@@ -1424,6 +1519,42 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                     "will be carved from the target repo's current HEAD"
                 )
 
+            # #2845: a RESUME into the implementation stage starts from the
+            # best state the halted attempt reached, not from the base. That
+            # state is on the graveyard branch RESTORE preserved; without
+            # this, the resume rebuilds from zero and repays the whole stage.
+            # Only on a resume -- a fresh draw (`--fresh`, or any first run)
+            # must start from the base, which is what `resumed_from` being
+            # empty means (#2383 makes that field explicit on both paths).
+            if state.get("resumed_from") == "impl":
+                recovered = _recoverable_attempt_branch(
+                    target_repo, issue_number, base_branch,
+                )
+                if recovered:
+                    recovered_branch, recovered_commits = recovered
+                    print(
+                        f"    Resuming from preserved attempt "
+                        f"{recovered_branch} ({recovered_commits} commit(s) "
+                        f"beyond {base_branch})"
+                    )
+                    # Replaces the base as the worktree's commit-ish. `-b
+                    # issue-{N}` still creates the branch, so everything
+                    # downstream -- checkpoints, the pr stage's head, the
+                    # #2310 disposal -- is unchanged. The base was appended
+                    # just above and is the last argument; it is matched
+                    # rather than indexed, so a future edit to the argument
+                    # order cannot silently retarget the worktree.
+                    if add_cmd and add_cmd[-1] == base_branch:
+                        add_cmd[-1] = recovered_branch
+                    else:
+                        add_cmd.append(recovered_branch)
+                else:
+                    print(
+                        f"    No preserved attempt for #{issue_number} is "
+                        f"resumable from '{base_branch}'; starting the "
+                        f"implementation from the base"
+                    )
+
             # #2310: a previous failed roll can leave `issue-{N}` standing.
             # `worktree add -b` then dies with a bare `fatal: a branch named
             # 'issue-7' already exists` (exit 255), which killed a roll whose
@@ -1450,6 +1581,23 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                     f"    Reusing leftover branch '{branch_name}' "
                     f"(pointer-identical to {base_branch or 'the base'})"
                 )
+                if recovered_branch:
+                    # #2845: adopting the leftover means the worktree starts
+                    # at the base after all, so the preserved attempt is not
+                    # in play. Said out loud rather than dropped in silence:
+                    # the run is about to implement from zero and the log
+                    # must be the reason it can be told from a recovery.
+                    # Disposal (#2310) safe-deletes a zero-unique
+                    # `issue-{N}`, so reaching here at all means a previous
+                    # RESTORE did not finish.
+                    print(
+                        f"    [WARN] preserved attempt {recovered_branch} "
+                        f"NOT used: '{branch_name}' is still standing from "
+                        f"an earlier roll, and adopting it starts from the "
+                        f"base. Preserve or free that name to resume from "
+                        f"the attempt."
+                    )
+                    recovered_branch = ""
                 add_cmd = ["git"]
                 if target_repo:
                     add_cmd += ["-C", target_repo]
@@ -1560,7 +1708,16 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # #1941: RESUMED lets the runner reuse a prior attempt's files;
             # REGENERATED forbids it. Absent on a first attempt, which reuses
             # nothing because there is nothing to reuse.
-            "retry_mode": state.get("retry_mode", ""),
+            #
+            # #2845: a worktree carved from a preserved attempt IS a later
+            # attempt, and must say so, or the red phase reads the surviving
+            # implementation as green-at-red and halts the stage as fatal --
+            # `_implementation_already_exists` consults no other signal on a
+            # sub-workflow entering fresh, with retry_mode empty and
+            # iteration_count zero. The recovery would otherwise turn a
+            # from-zero rebuild into a halt, which is worse than the defect
+            # it fixes.
+            "retry_mode": RESUMED if recovered_branch else state.get("retry_mode", ""),
             # #2344: seed the iteration cap explicitly. Left absent, each
             # reader fell back to its own inline default -- 5 in N5's progress
             # message, 3 in the router's decision -- so the run announced a

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8946,
-    "findings_total": 535
+    "sites_examined": 8963,
+    "findings_total": 536
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_impl_resume_from_preserved_attempt.py
+++ b/tests/unit/test_impl_resume_from_preserved_attempt.py
@@ -1,0 +1,376 @@
+"""A resume into the impl stage starts from the preserved attempt (#2845).
+
+RESTORE removes the implementation worktree on every exit (#2005), so the
+best-iteration snapshot `verify_phases._restore_best` takes dies with it. What
+survives is the attempt branch, renamed under `graveyard/` by the #2310
+disposal discipline.
+
+On boostgauge run 15 (`run-issue4-040403`, 2026-09-05) that branch held the
+whole 48-of-52-passing implementation -- eight files, 1,356 lines, over a
+post-scaffold and five post-impl checkpoints -- and the resume that followed
+carved its worktree from the base and implemented from zero. Five iterations
+at roughly thirty minutes each, repaid for nothing.
+
+Two halves are tested here, because either alone makes things worse:
+
+* the SELECTION -- which preserved attempt, if any, may be resumed from. Run
+  against a real git repository rather than a mocked one: every condition is
+  a git ancestry fact, and a mock of `merge-base` would be asserting that the
+  test author knows what ancestry means rather than that the code does.
+* the WIRING -- that the recovered branch reaches `git worktree add` as the
+  commit-ish, and that the sub-workflow is told this is a later attempt. Without
+  the second, the red phase reads the surviving implementation as green-at-red
+  and halts the stage as fatal (#2337), turning a slow rebuild into a dead run.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core.retry_mode import RESUMED
+from assemblyzero.workflows.orchestrator import stages
+
+
+# =============================================================================
+# Selection -- real git, real ancestry
+# =============================================================================
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str) -> None:
+    (repo / name).write_text(name, encoding="utf-8")
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", f"add {name}")
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo on `hardening-run-20` with one commit, ready for graves."""
+    root = tmp_path / "campaign"
+    root.mkdir()
+    _git(root, "init", "-b", "hardening-run-20")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    _commit(root, "base.txt")
+    return root
+
+
+def _grave(repo: Path, branch: str, commits: int = 1, base: str | None = None):
+    """Create `branch` off `base` (default: current HEAD) with `commits` on top."""
+    start = base or "HEAD"
+    _git(repo, "checkout", "-b", branch, start)
+    for i in range(commits):
+        _commit(repo, f"{branch.replace('/', '_')}-{i}.txt")
+    _git(repo, "checkout", "hardening-run-20")
+
+
+class TestSelection:
+    def test_the_preserved_attempt_is_returned_with_its_commit_count(self, repo):
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=6)
+
+        found = stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        )
+
+        assert found == ("graveyard/issue-4-20260905T114611Z", 6)
+
+    def test_the_newest_stamp_wins(self, repo):
+        _grave(repo, "graveyard/issue-4-20260902T010250Z", commits=2)
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=6)
+
+        found = stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        )
+
+        assert found is not None
+        assert found[0] == "graveyard/issue-4-20260905T114611Z"
+
+    def test_another_issues_grave_is_not_borrowed(self, repo):
+        """`--list graveyard/issue-4-*` also matches issue 41's graves. The
+        captured number is compared, so #4 never resumes #41's work."""
+        _grave(repo, "graveyard/issue-41-20260905T114611Z", commits=3)
+
+        assert stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        ) is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "graveyard/arc1-issue-4",
+            "graveyard/run11-roll10-issue-4",
+            "graveyard/issue-4-lld-20260905T114611Z",
+            "graveyard/issue-4-notastamp",
+        ],
+    )
+    def test_only_the_machinerys_own_disposal_names_are_read(self, repo, name):
+        """A campaign repo accumulates hand-made graveyard names. None of them
+        is a `dispose_pipeline_branches` attempt and none may be resumed from."""
+        _grave(repo, name, commits=3)
+
+        assert stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        ) is None
+
+    def test_a_grave_the_base_has_moved_past_is_left_alone(self, repo):
+        """The attempt was cut from an older base. Resuming it would rebuild
+        on a tree the campaign has moved off, so the honest answer is None and
+        the caller starts from the base."""
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=6)
+        _commit(repo, "base-moved-on.txt")
+
+        assert stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        ) is None
+
+    def test_a_grave_with_nothing_unique_is_not_resumed(self, repo):
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=0)
+
+        assert stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        ) is None
+
+    def test_an_older_usable_grave_is_taken_when_the_newest_is_stale(self, repo):
+        """Newest-first is a preference, not a rule: the loop keeps looking.
+
+        The newest STAMP is cut before the base moves on, so it is stale; the
+        older stamp is cut after, so it still descends from the base. Stamps
+        are names, and the order they were created in is not the order they
+        sort in -- which is exactly the case that would break a `max()`.
+        """
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=1)
+        _commit(repo, "base-moved-on.txt")
+        _grave(repo, "graveyard/issue-4-20260902T010250Z", commits=2)
+
+        found = stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        )
+
+        assert found == ("graveyard/issue-4-20260902T010250Z", 2)
+
+    def test_no_graves_at_all(self, repo):
+        assert stages._recoverable_attempt_branch(
+            str(repo), 4, "hardening-run-20"
+        ) is None
+
+    def test_an_unresolved_base_declines_rather_than_guessing(self, repo):
+        _grave(repo, "graveyard/issue-4-20260905T114611Z", commits=6)
+
+        assert stages._recoverable_attempt_branch(str(repo), 4, "") is None
+
+    def test_an_unreadable_repo_keeps_the_previous_behaviour(self, tmp_path):
+        assert stages._recoverable_attempt_branch(
+            str(tmp_path / "not-a-repo"), 4, "main"
+        ) is None
+
+
+# =============================================================================
+# Wiring -- what reaches git, and what reaches the sub-workflow
+# =============================================================================
+
+_ATTEMPT = "graveyard/issue-4-20260905T114611Z"
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    # mock-ok: subprocess boundary, and a REAL CompletedProcess (standard 0024).
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class _GitStub:
+    """Answers the ancestry questions as a repo holding one usable attempt.
+
+    Everything else succeeds silently, exactly as `_Recorder` does in
+    `test_impl_worktree_base.py` -- this stub only adds answers for the three
+    queries `_recoverable_attempt_branch` asks.
+    """
+
+    def __init__(self, attempt: str = _ATTEMPT, leftover_exists: bool = False):
+        self.attempt = attempt
+        self.leftover_exists = leftover_exists
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        cmd = list(cmd) if isinstance(cmd, list) else [cmd]
+        self.calls.append(cmd)
+        if "branch" in cmd and "--list" in cmd:
+            if any(a.startswith("graveyard/") for a in cmd):
+                return _completed(stdout=f"{self.attempt}\n" if self.attempt else "")
+            return _completed()
+        if "merge-base" in cmd:
+            return _completed()
+        if "rev-list" in cmd and "--count" in cmd:
+            # The grave carries six commits; a standing `issue-4` is
+            # pointer-identical to the base, which is what makes #2310 adopt
+            # it. Answering both from one branch would make this stub, not the
+            # code, decide which path runs.
+            ranged = cmd[-1]
+            return _completed(stdout="6\n" if "graveyard/" in ranged else "0\n")
+        if "show-ref" in cmd:
+            # #2310's leftover probe: non-zero means the branch is absent.
+            return _completed(returncode=1 if not self.leftover_exists else 0)
+        return _completed()
+
+    def worktree_add(self) -> list[str] | None:
+        for cmd in self.calls:
+            if "worktree" in cmd and "add" in cmd:
+                return cmd
+        return None
+
+
+@pytest.fixture
+def state(tmp_path):
+    target = tmp_path / "targetrepo"
+    target.mkdir()
+    return {
+        "issue_number": 4,
+        "target_repo": str(target),
+        "assemblyzero_root": str(tmp_path / "az"),
+        "base_branch": "hardening-run-20",
+    }
+
+
+def _run_impl(state, git):
+    with patch.object(stages, "run_command", git), \
+         patch.object(Path, "is_dir", return_value=False):
+        try:
+            stages.run_impl_stage(state)
+        except Exception:
+            # Downstream stage work is not under test; the worktree add and
+            # everything before it has already been recorded.
+            pass
+    return git.worktree_add()
+
+
+class TestWorktreeIsCarvedFromTheAttempt:
+    def test_resume_uses_the_preserved_attempt_as_the_commit_ish(self, state):
+        state["resumed_from"] = "impl"
+
+        cmd = _run_impl(state, _GitStub())
+
+        assert cmd is not None, "no worktree add was issued"
+        assert cmd[-1] == _ATTEMPT, cmd
+
+    def test_the_branch_it_creates_is_still_the_issue_branch(self, state):
+        """Everything downstream -- checkpoints, the pr stage's head, #2310's
+        disposal -- keys off `issue-{N}`. Only the base changes."""
+        state["resumed_from"] = "impl"
+
+        cmd = _run_impl(state, _GitStub())
+
+        assert cmd[cmd.index("-b") + 1] == "issue-4", cmd
+
+    def test_the_recovery_is_named_in_the_log(self, state, capsys):
+        state["resumed_from"] = "impl"
+
+        _run_impl(state, _GitStub())
+
+        out = capsys.readouterr().out
+        assert f"Resuming from preserved attempt {_ATTEMPT}" in out
+        assert "6 commit(s)" in out
+
+    def test_a_fresh_draw_still_starts_from_the_base(self, state):
+        """#2383 makes `resumed_from` explicit on the fresh path, so an empty
+        value is a first run and must behave exactly as it did before."""
+        state["resumed_from"] = ""
+
+        cmd = _run_impl(state, _GitStub())
+
+        assert cmd[-1] == "hardening-run-20", cmd
+
+    def test_a_resume_into_a_different_stage_does_not_touch_the_worktree_base(
+        self, state
+    ):
+        state["resumed_from"] = "spec"
+
+        cmd = _run_impl(state, _GitStub())
+
+        assert cmd[-1] == "hardening-run-20", cmd
+
+    def test_nothing_preserved_falls_through_to_the_base(self, state, capsys):
+        state["resumed_from"] = "impl"
+
+        cmd = _run_impl(state, _GitStub(attempt=""))
+
+        assert cmd[-1] == "hardening-run-20", cmd
+        assert "No preserved attempt for #4" in capsys.readouterr().out
+
+    def test_a_standing_leftover_branch_is_reported_not_silently_preferred(
+        self, state, capsys
+    ):
+        """#2310 adopts a pointer-identical `issue-{N}`, which starts the
+        worktree at the base after all. That is today's behaviour and stays,
+        but the abandoned recovery must be legible in the log -- otherwise the
+        run implements from zero and reads exactly like a successful resume."""
+        state["resumed_from"] = "impl"
+
+        cmd = _run_impl(state, _GitStub(leftover_exists=True))
+
+        assert _ATTEMPT not in cmd, cmd
+        out = capsys.readouterr().out
+        assert f"preserved attempt {_ATTEMPT} NOT used" in out
+
+
+class TestTheSubWorkflowIsToldItIsALaterAttempt:
+    """#2337: a red phase that finds the implementation already present is
+    fatal on a FIRST attempt. `_implementation_already_exists` consults only
+    `retry_mode` and `iteration_count`, both empty on a sub-workflow entering
+    fresh -- so without this the recovery halts the stage instead of resuming
+    it, which is strictly worse than the from-zero rebuild it replaces.
+    """
+
+    def _invoked_state(self, state, git):
+        seen: dict = {}
+
+        class _App:
+            def invoke(self, payload, config=None):
+                seen.update(payload)
+                raise RuntimeError("stop here: the payload is what is under test")
+
+        class _Graph:
+            def compile(self):
+                return _App()
+
+        with patch(
+            "assemblyzero.workflows.testing.graph.build_testing_workflow",
+            return_value=_Graph(),
+        ):
+            _run_impl(state, git)
+        return seen
+
+    def test_a_recovered_worktree_enters_as_RESUMED(self, state):
+        state["resumed_from"] = "impl"
+
+        seen = self._invoked_state(state, _GitStub())
+
+        assert seen.get("retry_mode") == RESUMED
+
+    def test_a_fresh_draw_carries_the_states_own_retry_mode(self, state):
+        state["resumed_from"] = ""
+        state["retry_mode"] = ""
+
+        seen = self._invoked_state(state, _GitStub())
+
+        assert seen.get("retry_mode") == ""
+
+    def test_a_stage_retrys_own_mode_is_not_overwritten_without_a_recovery(
+        self, state
+    ):
+        """#1941's REGENERATED must survive: a deterministic failure's next
+        attempt still regenerates when no attempt was recovered."""
+        state["resumed_from"] = ""
+        state["retry_mode"] = "REGENERATED"
+
+        seen = self._invoked_state(state, _GitStub())
+
+        assert seen.get("retry_mode") == "REGENERATED"

--- a/tests/unit/test_retry_mode.py
+++ b/tests/unit/test_retry_mode.py
@@ -195,9 +195,24 @@ def test_graph_records_the_mode_and_threads_it_to_the_next_attempt():
 
 
 def test_impl_stage_passes_retry_mode_to_the_sub_workflow():
+    """The mode the graph recorded must reach the sub-workflow's payload.
+
+    #2845 gave this line a second source -- a worktree recovered from a
+    preserved attempt enters as RESUMED whatever the state says -- so the
+    assertion is on the two parts that must survive any such addition: the
+    payload carries the key, and the state's own mode is still what it falls
+    back to. Matching the whole expression made an ADDITION look like a
+    removal. The override itself is tested behaviourally, against the payload
+    the sub-workflow actually receives, in
+    `test_impl_resume_from_preserved_attempt.py`.
+    """
     import inspect
 
     from assemblyzero.workflows.orchestrator import stages
 
     source = inspect.getsource(stages.run_impl_stage)
-    assert '"retry_mode": state.get("retry_mode", "")' in source
+    assert '"retry_mode":' in source
+    assert 'state.get("retry_mode", "")' in source, (
+        "the state's mode must remain the fallback, or an ordinary stage "
+        "retry stops regenerating"
+    )


### PR DESCRIPTION
## The defect

`restore_repo` (#2005) calls `reset.remove_worktree` on every exit, so the best-iteration snapshot `verify_phases._restore_best` takes dies with the worktree it was restored into. What survives is the attempt branch, renamed under `graveyard/` by the #2310 disposal discipline — and no resume read it.

On boostgauge run 15 (`run-issue4-040403`, 2026-09-05) the green loop halted at its cap with **48 of 52 tests passing at 93 % coverage** after five iterations. `graveyard/issue-4-20260905T114611Z` still holds all of it: eight files, 1,356 lines, over a post-scaffold and five post-impl checkpoints. The resume that followed printed `RESUME #4 from 'impl' -- passed stages reused`, carved a fresh worktree from the base, scaffolded, failed red, and implemented from nothing. Five iterations at roughly thirty minutes each, repaid for zero.

## The change

A resume into the implementation stage now starts from the best state the halted attempt reached. `_recoverable_attempt_branch` picks the newest `graveyard/issue-{N}-<stamp>` and `run_impl_stage` hands it to `git worktree add` as the commit-ish in place of the base. `-b issue-{N}` is unchanged, so checkpoints, the pr stage's head, and the #2310 disposal all key off the same name they always did.

**Two conditions, both measured, before a grave is offered back:**

- the base branch is an **ancestor** of it — this is what proves the attempt was cut from the base this run is rolling on. A grave from an earlier phase, or from before the base moved, fails and is left alone.
- it carries commits the base does not.

Anything unprovable falls through to the base. Resuming stale work is worse than an honest start from zero, so every git failure resolves to "no recovery" and the previous behaviour.

**The sub-workflow is told it is a later attempt** (`retry_mode` = `RESUMED`). This half is not optional. `_implementation_already_exists` consults only `retry_mode` and `iteration_count`, both empty on a sub-workflow entering fresh — so without it #2337's red phase reads the surviving implementation as green-at-red and halts the stage as fatal. The recovery alone would have converted a slow rebuild into a dead run.

A fresh draw is untouched: `resumed_from` is empty on that path (#2383) and the base is still the commit-ish.

## Verified against the real data

`graveyard/issue-4-20260905T114611Z` measured in the live boostgauge repo: base `hardening-run-20` **is** an ancestor, 6 unique commits, and `git diff --stat` against the base is exactly the 8 files / 1,356 lines run 15 produced. The selection this PR adds returns that branch.

## Tests

`tests/unit/test_impl_resume_from_preserved_attempt.py`, 23 cases in two halves.

Selection runs against a **real git repository**, not a mocked one — every condition is a git ancestry fact, and a mocked `merge-base` would assert that the test author knows what ancestry means rather than that the code does. It covers the newest stamp winning; an older grave being taken when the newest is stale (the case a `max()` would get wrong); `graveyard/issue-41-*` not being borrowed by issue 4; the hand-made campaign names (`graveyard/arc1-issue-4`, `graveyard/run11-roll10-issue-4`) being ignored; a grave the base has moved past; a grave with nothing unique; an unresolved base; and an unreadable repo.

Wiring asserts on the argv handed to git and on the payload the sub-workflow receives, following `test_impl_worktree_base.py`. The load-bearing one is `test_a_recovered_worktree_enters_as_RESUMED` — confirmed to fail when the `RESUMED` wiring is reverted and to pass with it.

One behaviour is deliberately reported rather than changed: when a leftover `issue-{N}` is still standing, #2310 adopts it and the worktree starts at the base after all, so the recovery is dropped. Disposal safe-deletes a zero-unique `issue-{N}`, so reaching that state means an earlier RESTORE did not finish. It now says so in the log instead of reading like a successful resume.

## Suites run

`tests/unit` in full: 10,194 passed. Two failures are `test_section_ten_carries_tests`, which reads boostgauge's live lineage — that is #2834, confirmed failing identically on a clean `origin/main` checkout, and untouched here.

`tests/unit/test_retry_mode.py::test_impl_stage_passes_retry_mode_to_the_sub_workflow` matched the whole `"retry_mode": state.get("retry_mode", "")` expression as a source string, so an **addition** read as a removal. It now asserts the two parts that must survive such an addition — the payload carries the key, and the state's own mode is still the fallback — and points at the behavioural coverage for the override.

`tools/audit_fail_open.py` flagged the candidate loop's `continue`-on-unmeasurable, correctly. It is a deliberate fail-open in the safe direction and now carries a `# fail-open:` ruling in the code; the baseline was regenerated, and its diff is the denominator alone — no new undeclared site.

## One thing the issue asked for that is not here

The acceptance list asked the log to name "N passing at M percent". The halted attempt's passing count is not persisted anywhere a resume can read — the stage result records the failing count, not the passing one. Rather than remember a number, the log names the branch and how many commits it carries, and N5's first measurement prints the real count moments later. A measured number beats a remembered one, and adding a persisted count is its own change.

Closes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
