### PR TITLE
fix: retry_mode is a declared channel of the testing sub-workflow, and every key the impl stage sends is (Closes #2847, Closes #2848, Closes #2849)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1681,7 +1681,6 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
         )
         from assemblyzero.workflows.testing.state import DEFAULT_MAX_ITERATIONS
 
-        spec_path = state.get("spec_path", "")
         # #1440: Plumb orchestrator config into the sub-workflow state.
         config = state.get("config", {})
         stage_cfg = config.get("stages", {}).get("impl", {})
@@ -1693,9 +1692,16 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
         # on the issue-{N} branch. original_repo_root stays as target_repo
         # so load_lld.py's fallback (Issue #380) can find the LLD that
         # lives on target_repo's main.
+        # #2847: every key below is a declared channel of TestingWorkflowState,
+        # and tests/unit/test_impl_invoke_payload_is_declared.py holds it so.
+        # LangGraph discards an undeclared key at the invoke boundary without
+        # a word (#2018, #2679); three keys here were being discarded, one of
+        # them the retry_mode #1941 and #2845 both depended on. `spec_path`
+        # was one of the three and is gone: the schema never declared it and
+        # no testing node reads it -- N0 finds the spec through `lld_path`
+        # and its own search (#2848).
         sub_result = app.invoke({
             "issue_number": issue_number,
-            "spec_path": spec_path,
             "worktree_path": str(worktree_path),
             "repo_root": str(worktree_path),
             "original_repo_root": target_repo,
@@ -1724,7 +1730,12 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # budget it did not have and a freeze's loop-back was dropped at 3
             # without a word.
             "max_iterations": DEFAULT_MAX_ITERATIONS,
-            "config_mock_mode": mock_mode(state),
+            # #2849: `mock_mode` is the TESTING schema's field and the name all
+            # nine of its readers ask for. `config_mock_mode` is the spec
+            # workflow's field -- the spec invoke above sends it to a schema
+            # that declares it. Sent here it was undeclared, dropped, and a
+            # --mock rehearsal ran this stage's nodes for real.
+            "mock_mode": mock_mode(state),
         }, config={"recursion_limit": impl_recursion_limit(DEFAULT_MAX_ITERATIONS)})
 
         error_msg = sub_result.get("error_message", "")

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -275,6 +275,15 @@ class TestingWorkflowState(TypedDict, total=False):
     test_plan_revision_count: int  # Issue #1072: incremented per revision cycle
     auto_mode: bool
     mock_mode: bool
+    #: #1941: RESUMED or REGENERATED, set by the orchestrator on a stage retry;
+    #: #2845 sets RESUMED when the worktree was carved from a preserved
+    #: attempt. MUST stay declared (#2847): it was sent from the day #1941
+    #: landed and never arrived, because an undeclared key is discarded by
+    #: LangGraph at the invoke boundary (#2018). `is_regeneration` always read
+    #: None, and the red phase refused #2845's recovered worktree as
+    #: green-at-red on run-issue4-113418 because `_implementation_already_exists`
+    #: gates on this field and saw it empty.
+    retry_mode: str
     skip_e2e: bool
     scaffold_only: bool
     green_only: bool

--- a/tests/unit/test_impl_invoke_payload_is_declared.py
+++ b/tests/unit/test_impl_invoke_payload_is_declared.py
@@ -1,0 +1,211 @@
+"""Every key the impl stage hands its sub-workflow is a declared channel (#2847).
+
+LangGraph builds a graph's state channels from the schema it is given.
+A key in the invoke payload that the schema does not declare is discarded
+before the first node runs -- silently, with the payload otherwise intact, so
+the sender has every reason to believe it arrived. `TestingWorkflowState`
+already carries three comments saying exactly this about fields that were
+lost that way (#2018, #2050, #2679).
+
+`run_impl_stage` was sending three such keys:
+
+* `retry_mode` (#1941, and RESUMED from #2845) -- so `is_regeneration` always
+  read None, and on run-issue4-113418 the red phase refused a worktree
+  carved from run 15's 48-of-52 implementation as green-at-red, because
+  `_implementation_already_exists` gates on this field and saw it empty;
+* `config_mock_mode` (#2849) -- the SPEC workflow's field name; the testing
+  nodes read `mock_mode`, so a --mock rehearsal ran this stage for real;
+* `spec_path` (#2848) -- read by nothing; N0 finds the spec its own way.
+
+The first test here is the general guard: it reads the payload the stage
+actually sends and the schema the sub-workflow actually declares, and fails
+on any difference. That is `test_scaffold_route_carried.py`'s rule -- the
+schema IS the merge contract -- applied to the orchestrator's side of the
+boundary. The rest prove the value survives into a node, not just that the
+name is in a TypedDict.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core.retry_mode import RESUMED
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    # mock-ok: subprocess boundary, and a REAL CompletedProcess (standard 0024).
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _quiet_git(cmd, *args, **kwargs):
+    """Every git call succeeds with empty output: no graves, no leftovers."""
+    cmd = list(cmd) if isinstance(cmd, list) else [cmd]
+    if "show-ref" in cmd:
+        return _completed(returncode=1)  # no leftover `issue-N` branch
+    return _completed()
+
+
+def _payload_sent_by_run_impl_stage(state: dict) -> dict:
+    """The exact dict `run_impl_stage` hands to `app.invoke`."""
+    seen: dict = {}
+
+    class _App:
+        def invoke(self, payload, config=None):
+            seen.update(payload)
+            raise RuntimeError("stop here: the payload is what is under test")
+
+    class _Graph:
+        def compile(self):
+            return _App()
+
+    with patch.object(stages, "run_command", _quiet_git), \
+         patch.object(Path, "is_dir", return_value=False), \
+         patch(
+             "assemblyzero.workflows.testing.graph.build_testing_workflow",
+             return_value=_Graph(),
+         ):
+        try:
+            stages.run_impl_stage(state)
+        except Exception:
+            pass
+    assert seen, "run_impl_stage never reached app.invoke"
+    return seen
+
+
+@pytest.fixture
+def state(tmp_path):
+    target = tmp_path / "targetrepo"
+    target.mkdir()
+    return {
+        "issue_number": 4,
+        "target_repo": str(target),
+        "assemblyzero_root": str(tmp_path / "az"),
+        "base_branch": "hardening-run-20",
+        "resumed_from": "",
+        "retry_mode": "",
+    }
+
+
+class TestThePayloadMatchesTheSchema:
+    def test_every_key_sent_is_a_declared_channel(self, state):
+        """The general guard. A key here that the schema lacks is a value the
+        orchestrator believes it sent and the sub-workflow never receives."""
+        payload = _payload_sent_by_run_impl_stage(state)
+
+        undeclared = set(payload) - set(TestingWorkflowState.__annotations__)
+        assert not undeclared, (
+            f"run_impl_stage sends key(s) TestingWorkflowState does not "
+            f"declare -- LangGraph drops them at invoke, silently: "
+            f"{sorted(undeclared)}"
+        )
+
+    def test_retry_mode_is_declared(self):
+        assert "retry_mode" in TestingWorkflowState.__annotations__, (
+            "retry_mode is not a channel of TestingWorkflowState -- #1941's "
+            "mode and #2845's RESUMED are dropped before N0 (#2847)"
+        )
+
+    def test_the_stage_sends_the_name_the_testing_nodes_read(self, state):
+        """#2849: `mock_mode`, not the spec workflow's `config_mock_mode`."""
+        payload = _payload_sent_by_run_impl_stage(state)
+
+        assert "mock_mode" in payload
+        assert "config_mock_mode" not in payload
+
+    def test_the_stage_does_not_send_the_dead_spec_path_key(self, state):
+        """#2848: nothing in the testing workflow reads it."""
+        payload = _payload_sent_by_run_impl_stage(state)
+
+        assert "spec_path" not in payload
+
+
+class TestTheValueSurvivesIntoANode:
+    """Declaring the name is the fix; this is the proof it is sufficient.
+
+    A real `StateGraph(TestingWorkflowState)` with one node that records what
+    it was handed. Before #2847 this graph drops `retry_mode` on the floor and
+    the node sees nothing -- the exact mechanism, not a description of it.
+    """
+
+    def _what_one_node_receives(self, payload: dict) -> dict:
+        from langgraph.graph import END, StateGraph
+
+        received: dict = {}
+
+        def probe(s):
+            received.update(dict(s))
+            return {}
+
+        graph = StateGraph(TestingWorkflowState)
+        graph.add_node("probe", probe)
+        graph.set_entry_point("probe")
+        graph.add_edge("probe", END)
+        graph.compile().invoke(payload)
+        return received
+
+    def test_retry_mode_reaches_the_first_node(self):
+        received = self._what_one_node_receives(
+            {"issue_number": 4, "retry_mode": RESUMED}
+        )
+
+        assert received.get("retry_mode") == RESUMED
+
+    def test_mock_mode_reaches_the_first_node(self):
+        received = self._what_one_node_receives(
+            {"issue_number": 4, "mock_mode": True}
+        )
+
+        assert received.get("mock_mode") is True
+
+    def test_an_undeclared_key_really_is_dropped(self):
+        """The premise of this whole module, demonstrated rather than asserted:
+        a name the schema lacks does not arrive. If LangGraph ever stops doing
+        this, the guard above becomes unnecessary and this test says so."""
+        received = self._what_one_node_receives(
+            {"issue_number": 4, "no_such_channel_2847": "sent"}
+        )
+
+        assert "no_such_channel_2847" not in received
+
+
+class TestTheRedPhaseNowReadsTheSignal:
+    """The consequence that mattered: with `retry_mode` arriving, a worktree
+    that already holds the planned files is this run's own progress, not
+    green-at-red. This is the predicate the red phase consults (#2337/#2542),
+    fed the state a resumed sub-workflow now actually carries."""
+
+    def test_resumed_with_planned_files_present_is_a_later_attempt(self, tmp_path):
+        from assemblyzero.workflows.testing.nodes import verify_phases
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "collector.py").write_text("x = 1\n", encoding="utf-8")
+        state = {
+            "repo_root": str(tmp_path),
+            "retry_mode": RESUMED,
+            "iteration_count": 0,
+            "files_to_modify": [{"path": "src/collector.py", "change_type": "Add"}],
+        }
+
+        assert verify_phases._implementation_already_exists(state) is True
+
+    def test_a_first_attempt_is_still_not(self, tmp_path):
+        """The guard #2337 was built for must still fire on a genuine first
+        entry: same files on disk, no retry_mode, iteration zero."""
+        from assemblyzero.workflows.testing.nodes import verify_phases
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "collector.py").write_text("x = 1\n", encoding="utf-8")
+        state = {
+            "repo_root": str(tmp_path),
+            "retry_mode": "",
+            "iteration_count": 0,
+            "files_to_modify": [{"path": "src/collector.py", "change_type": "Add"}],
+        }
+
+        assert verify_phases._implementation_already_exists(state) is False

--- a/tests/unit/test_orchestrator_lineage.py
+++ b/tests/unit/test_orchestrator_lineage.py
@@ -418,9 +418,12 @@ class TestTheAuditActuallyInspectsSomething:
             f"expected exactly the three invoking stages, found {sorted(payloads)}"
         )
         # Sentinel keys that have been in these payloads for many issues.
+        # (#2848 retired `spec_path` from the impl payload -- the testing
+        # schema never declared it and no node read it. `worktree_path` is
+        # the key that payload exists to carry, per #1504.)
         assert "issue_number" in payloads["run_spec_stage"]
         assert "workflow_type" in payloads["run_lld_stage"]
-        assert "spec_path" in payloads["run_impl_stage"]
+        assert "worktree_path" in payloads["run_impl_stage"]
 
     def test_the_spec_workflow_is_still_the_one_that_cannot_self_provision(self):
         """Pins the asymmetry the fix rests on. If implementation_spec ever

--- a/tests/unit/test_rehearsal_pair.py
+++ b/tests/unit/test_rehearsal_pair.py
@@ -144,15 +144,45 @@ class TestMockModeIsReadFromConfig:
 
 class TestEverySubWorkflowStageGetsTheFlag:
     """The hardcoded False was at exactly one of three sites, which is the
-    argument for reading it from config rather than passing it to each."""
+    argument for reading it from config rather than passing it to each.
 
-    @pytest.mark.parametrize("stage", ["lld", "spec", "impl"])
-    def test_the_stage_passes_mock_mode_through(self, stage):
-        source = (
-            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
-        ).read_text(encoding="utf-8")
-        assert source.count('"config_mock_mode": mock_mode(state)') == 3, (
-            "all three sub-workflow stages must source the flag from config"
+    #2849: the flag must be sent under the name the RECEIVING schema declares,
+    and the three sub-workflows do not agree on it. requirements and
+    implementation_spec declare `config_mock_mode`; testing declares
+    `mock_mode`, and all nine of its readers ask for that. This test used to
+    count one literal three times across stages.py, which held the impl stage
+    to the wrong name -- LangGraph dropped the undeclared key, and a --mock
+    rehearsal ran the impl stage's nodes for real. Each stage is now checked
+    against its own sub-workflow's schema, which is the assertion that would
+    have failed then.
+    """
+
+    @pytest.mark.parametrize(
+        "stage, key, schema_module",
+        [
+            ("lld", "config_mock_mode", "assemblyzero.workflows.requirements.state"),
+            ("spec", "config_mock_mode", "assemblyzero.workflows.implementation_spec.state"),
+            ("impl", "mock_mode", "assemblyzero.workflows.testing.state"),
+        ],
+    )
+    def test_the_stage_passes_mock_mode_through(self, stage, key, schema_module):
+        import importlib
+        import inspect
+
+        source = inspect.getsource(getattr(st, f"run_{stage}_stage"))
+        assert f'"{key}": mock_mode(state)' in source, (
+            f"run_{stage}_stage must send the flag from config under the name "
+            f"its sub-workflow declares ({key})"
+        )
+
+        module = importlib.import_module(schema_module)
+        schema = next(
+            v for k, v in vars(module).items()
+            if k.endswith("State") and hasattr(v, "__annotations__")
+        )
+        assert key in schema.__annotations__, (
+            f"{schema_module} does not declare {key}; the flag run_{stage}_stage "
+            f"sends is dropped at the invoke boundary (#2849)"
         )
 
     def test_no_site_hardcodes_it_any_more(self):
@@ -160,6 +190,7 @@ class TestEverySubWorkflowStageGetsTheFlag:
             ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
         ).read_text(encoding="utf-8")
         assert '"config_mock_mode": False' not in source
+        assert '"mock_mode": False' not in source
 
 
 class TestARehearsalReachesNothingOutward:


### PR DESCRIPTION
## What happened

`run-issue4-113418` (today, 11:34) resumed boostgauge #4 with #2845 live. The recovery worked — `Resuming from preserved attempt graveyard/issue-4-20260905T114611Z (6 commit(s) beyond hardening-run-20)` — and the worktree held run 15's 48-of-52 implementation. The red phase then ran the spec's 12 tests, saw `8 passed, 4 failed`, and halted:

```
[GUARD] WARNING: 8 tests passed unexpectedly!
No red-entry marker and no prior-attempt writes explain them: the implementation existed BEFORE this stage entered.
```

`_implementation_already_exists` gates on `bool(state.get("retry_mode")) or iteration_count > 0`. #2845 sent `retry_mode = RESUMED` for exactly this. It never arrived.

## Why

LangGraph builds a graph's state channels from the schema it is given, and discards an undeclared key in the invoke payload before the first node runs — silently, with the payload otherwise intact. `TestingWorkflowState` had no `retry_mode` field. The schema already carries three comments saying exactly this about other fields lost the same way (#2018, #2050, #2679), and `test_scaffold_route_carried.py` exists because a repair shipped inert through this mechanism once before.

Measured against `state.py`, **`run_impl_stage` was sending three undeclared keys**:

| key | since | what it cost |
|---|---|---|
| `retry_mode` | #1941 | `is_regeneration` has always read `None`; #2337's comment noticed the effect was absent ("It discards nothing") and explained it as scope rather than as the value never arriving. And today's halt. |
| `config_mock_mode` | #2288 | That is the **spec** workflow's field name. The testing nodes — all nine readers — ask for `mock_mode`. A `--mock` rehearsal ran this stage's nodes for real. |
| `spec_path` | — | Read by nothing. N0 finds the spec through `lld_path` and its own main-repo search, which is why the drop never showed. |

## The change

- `TestingWorkflowState` declares `retry_mode: str`, with the comment that says why it must stay declared (the same form the schema uses for `original_lld_path`, `best_iteration`, `zero_collected_strikes`).
- `run_impl_stage` sends `mock_mode`, the name the testing nodes read. The spec invoke keeps `config_mock_mode`; that schema declares it.
- `run_impl_stage` stops sending `spec_path`.

Three lines of source. The rest is the guard.

## Tests

`tests/unit/test_impl_invoke_payload_is_declared.py`, nine cases.

**The general guard** reads the payload `run_impl_stage` actually hands to `app.invoke` and the schema the sub-workflow actually declares, and fails on any key in the first that is not in the second. That is `test_scaffold_route_carried.py`'s rule — the schema IS the merge contract — applied to the orchestrator's side of the boundary. A fourth silent drop by omission fails CI.

**The mechanism, demonstrated rather than described.** A real `StateGraph(TestingWorkflowState)` with one probe node: `retry_mode` arrives, `mock_mode` arrives, and a key the schema lacks does not. If LangGraph ever stops dropping undeclared keys, that last test says so and the guard becomes optional.

**The consequence that mattered.** `_implementation_already_exists` fed the state a resumed sub-workflow now actually carries returns True; a genuine first attempt with the same files on disk still returns False, so the guard #2337 was built for still fires.

Confirmed to fail without the fix: with `retry_mode: str` removed from the schema, `test_retry_mode_reaches_the_first_node` and `test_every_key_sent_is_a_declared_channel` both go red.

Neighbouring suites (impl worktree base, preserved-attempt resume, retry_mode, scaffold-route, orchestrator stages, provisioning, repo targeting, completion marker, restore-best): 150 passed.

**Two existing tests had codified the defect and are repaired here.** `test_rehearsal_pair.py::test_the_stage_passes_mock_mode_through` counted the literal `"config_mock_mode": mock_mode(state)` three times across `stages.py` — it held the impl stage to the *spec* schema's name, which is #2849 written down as a requirement. It now checks each stage's source against its own sub-workflow's schema, which is the assertion that would have failed in the first place. `test_orchestrator_lineage.py::test_the_ast_scan_finds_the_real_payloads` used `spec_path` as its sentinel that the AST scan had found the impl payload; the sentinel is now `worktree_path`, the key that payload exists to carry (#1504).

Full `tests/unit`: 10,202 passed. The remaining two failures are `test_section_ten_carries_tests` — #2834, which reads boostgauge's live lineage, confirmed failing identically on a clean `origin/main`.

## What this does not change

A real roll's `mock_mode` is False, so sending it under the right name changes nothing on a real roll. A stage retry's `retry_mode` now reaches the sub-workflow for the first time, which means #1941's REGENERATED will do what #1941 designed — stop N4 skipping files a deterministic failure's previous attempt wrote. That is the behaviour the issue asked for and the comment on `graph.py` describes; it has simply never run.

Closes #2847
Closes #2848
Closes #2849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
