### PR TITLE
fix: a file's edit-script prompt carries the failures that file owns, and a file no failure names is left alone (Closes #2851)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
@@ -154,46 +154,108 @@ def should_use_edit_script(
     return True
 
 
+def _file_tokens(filepath: str) -> set[str]:
+    """The names a failure line would carry if this file were implicated.
+
+    `src/boostgauge/skins/stingray.py` -> boostgauge.skins.stingray, the bare
+    stem, the path itself, and `test_stingray` -- the runner names the test,
+    and the fix lands in the module under it.
+    """
+    path = Path(filepath)
+    stem = path.stem
+    if not stem:
+        return set()
+    parts = [p for p in path.with_suffix("").parts if p not in ("src", "lib")]
+    return {
+        stem.lower(),
+        ".".join(parts).lower(),
+        str(path).replace("\\", "/").lower(),
+        f"test_{stem}".lower(),
+    }
+
+
+def _attributed_blocks(failure_summary: str, filepath: str) -> list[str]:
+    """The blank-line-separated blocks of the corpus that name this file.
+
+    #2851: attribution is per BLOCK, not per line. A traceback block is a test
+    name, a frame, a source line and its `E` lines; the frame is the line that
+    names the owning file (`src/boostgauge/collector.py:116: in
+    _is_unleashed_session`), and keeping only that line would hand the model a
+    filename with no error under it. Lines are slash-normalised before the
+    match because pytest prints Windows frames with backslashes and the tokens
+    are built with forward slashes.
+    """
+    tokens = _file_tokens(filepath)
+    if not tokens:
+        return []
+    kept: list[str] = []
+    for block in _blocks(failure_summary):
+        haystack = block.replace("\\", "/").lower()
+        if any(token in haystack for token in tokens):
+            kept.append(block)
+    return kept
+
+
+def _blocks(failure_summary: str) -> list[str]:
+    """Split the summary into its units, by the one rule all three shapes obey.
+
+    A line at column 0 opens a unit; indented lines continue it; a blank line
+    ends it. That reads a bare `FAILED path::test - reason` line as a unit of
+    its own, a grouped entry (`N test(s): reason` over an indented `e.g.`) as
+    one unit, and a traceback block (test name over an indented frame, source
+    line and `E` lines) as one unit -- so the frame that names the file and
+    the error it explains are never separated.
+    """
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in failure_summary.splitlines():
+        if not line.strip():
+            if current:
+                blocks.append("\n".join(current))
+                current = []
+            continue
+        if not line[0].isspace() and current:
+            blocks.append("\n".join(current))
+            current = []
+        current.append(line.rstrip())
+    if current:
+        blocks.append("\n".join(current))
+    return blocks
+
+
+def is_attributed(failure_summary: str, filepath: str) -> bool:
+    """Does at least one failure in the corpus name this file?
+
+    The caller's decision (#2851): when the corpus attributes to SOME file,
+    a file it does not attribute to has nothing to fix this iteration and is
+    left alone -- not sent the whole corpus with an order to fix all of it.
+    """
+    return bool(_attributed_blocks(failure_summary, filepath))
+
+
 def failures_for_file(failure_summary: str, filepath: str) -> str:
     """The failures this file is implicated in, or everything if unattributable.
 
     The issue asks to "scope the prompt to the failing tests rather than the
     full failure corpus WHERE THE RUNNER CAN ATTRIBUTE failures to files". The
-    conditional is load-bearing and is honoured literally: pytest names the
-    failing TEST file, not the implementation file, so attribution runs on the
-    module name and the file stem, and when nothing matches the caller gets the
-    whole corpus back. Silently narrowing to nothing would starve the fix of
-    the information it needs, which is a worse failure than a prompt that is
-    larger than necessary.
+    conditional is load-bearing and is honoured literally: when nothing
+    matches the caller gets the whole corpus back. Silently narrowing to
+    nothing would starve the fix of the information it needs, which is a worse
+    failure than a prompt that is larger than necessary.
+
+    #2851: what "matches" means changed. It used to be a line-by-line filter
+    over a summary whose traceback section had no frame lines and whose
+    "source line" was a caret underline, so on run-issue4-120049 nothing ever
+    matched and all six files were told to fix all four failures. Blocks are
+    kept whole now, and the frame `_extract_traceback_blocks` emits is what
+    they match on.
     """
     if not failure_summary.strip():
         return failure_summary
-
-    path = Path(filepath)
-    stem = path.stem
-    if not stem:
-        return failure_summary
-
-    # `src/boostgauge/skins/stingray.py` -> boostgauge.skins.stingray, and the
-    # bare stem, and the path itself. A failure mentioning any of them is this
-    # file's business.
-    parts = [p for p in path.with_suffix("").parts if p not in ("src", "lib")]
-    tokens = {
-        stem.lower(),
-        ".".join(parts).lower(),
-        str(path).replace("\\", "/").lower(),
-    }
-    # `test_gauge.py` implicates `gauge.py`: the runner names the test, and the
-    # fix lands in the module under it.
-    tokens.add(f"test_{stem}".lower())
-
-    kept = [
-        line for line in failure_summary.splitlines()
-        if any(token and token in line.lower() for token in tokens)
-    ]
+    kept = _attributed_blocks(failure_summary, filepath)
     if not kept:
         return failure_summary
-    return "\n".join(kept)
+    return "\n\n".join(kept)
 
 
 def build_code_edit_script_prompt(
@@ -221,9 +283,10 @@ def build_code_edit_script_prompt(
         "1-15 lines).\n"
         "2. To INSERT new code, SEARCH for the nearest existing anchor "
         "line(s) and REPLACE with those same anchor lines plus the new code.\n"
-        "3. Emit one edit block per fix. Fix ALL the failures listed below. "
-        "Touch NOTHING else -- code you do not name in a SEARCH block cannot "
-        "and must not change, and the passing tests depend on that.\n"
+        "3. Emit one edit block per fix. Fix the failures listed below that "
+        "this file is responsible for. Touch NOTHING else -- code you do not "
+        "name in a SEARCH block cannot and must not change, and the passing "
+        "tests depend on that.\n"
         "4. No preamble, no explanation, no markdown fences around the "
         "blocks -- edit blocks only."
     ]

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -16,6 +16,7 @@ from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import 
     apply_code_edit_script,
     build_code_edit_script_prompt,
     failures_for_file,
+    is_attributed,
     response_is_a_regeneration,
     should_use_edit_script,
 )
@@ -712,6 +713,33 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             "rewriting implementation only, against the tests as written"
         )
 
+    # #2851: which files the failures actually name, decided once per
+    # iteration. On run-issue4-120049 every one of six files was handed all
+    # four failures and told to fix all of them; the one file that owned three
+    # of the fixes took 3 minutes, and the files that could not do what they
+    # were told took 25-33 minutes each. When the corpus attributes to at
+    # least one file, a file it does not name has nothing to fix this
+    # iteration and is left as it is. When it attributes to none, every file
+    # gets the whole corpus, as before -- narrowing to nothing is worse than a
+    # prompt that is larger than it should be.
+    attributed_paths: set[str] = set()
+    if revision_error_context:
+        attributed_paths = {
+            spec["path"] for spec in files_to_modify
+            if is_attributed(revision_error_context, spec["path"])
+        }
+        if attributed_paths:
+            print(
+                f"    [N4] failures attributed to {len(attributed_paths)} of "
+                f"{len(files_to_modify)} file(s): "
+                + ", ".join(sorted(attributed_paths))
+            )
+        else:
+            print(
+                "    [N4] failures attributed to no file by traceback; every "
+                "file receives the whole failure set"
+            )
+
     for i, file_spec in enumerate(files_to_modify):
         filepath = file_spec["path"]
         change_type = file_spec.get("change_type", "Add")
@@ -920,6 +948,33 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         # learned this in #1528; this is the implementation stage inheriting
         # it. Any failure returns None and falls through to the full-file path
         # below, so this is never worse than the behavior it replaces.
+        # #2851: a file the failures do not name, in an iteration where they
+        # do name some other file, is left unchanged -- no call at all. The
+        # bookkeeping mirrors the skip-on-resume branch above so the file
+        # still counts as this iteration's output.
+        if (
+            attributed_paths
+            and filepath not in attributed_paths
+            and target_path.exists()
+        ):
+            try:
+                unchanged = target_path.read_text(encoding="utf-8")
+            except OSError:
+                # fail-open: the file on disk is left exactly as it is either
+                # way -- this branch changes nothing. What is lost is only the
+                # copy of its text carried as context for the files after it.
+                # The alternative, falling through to a model call on a file
+                # no failure names, is the waste #2851 exists to remove, and a
+                # read hiccup is not a reason to reintroduce it.
+                unchanged = ""
+            print(
+                f"        [EDIT-SCRIPT] no failure attributed to {filepath}; "
+                f"left unchanged this iteration"
+            )
+            completed_files.append((filepath, unchanged))
+            written_paths.append(str(target_path))
+            continue
+
         code = None
         if should_use_edit_script(
             change_type, edit_script_content, revision_error_context

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -238,6 +238,12 @@ def _build_failure_summary(output: str) -> str:
     return result
 
 
+#: A pytest `--tb=short` frame: `path/to/file.py:116: in some_function`.
+#: Matched on the stripped line, so indentation and Windows backslashes are
+#: both fine (#2851).
+_TRACEBACK_FRAME = re.compile(r"^\S+?\.py:\d+: in \S+")
+
+
 def _extract_traceback_blocks(output: str) -> str:
     """Pull distinct failure tracebacks out of pytest's FAILURES section.
 
@@ -280,14 +286,42 @@ def _extract_traceback_blocks(output: str) -> str:
         if not error_lines:
             continue
 
-        # The last non-E, non-blank line before the errors is the source line
-        # that raised -- the single most useful line in the block.
+        # The innermost frame before the errors names the file that raised,
+        # and the line after it is the source line -- the two most useful
+        # lines in the block. #2851: this used to keep "the last non-blank
+        # line before E", which on Python 3.11+ is the caret underline
+        # (`    ^^^^^^^`), not the code, and it never kept the frame at all.
+        # So the reviser was shown carets, and the edit-script attribution
+        # downstream never saw `src\boostgauge\collector.py:116: in
+        # _is_unleashed_session` -- the one line that says which file owns
+        # the failure -- and handed every file the whole corpus.
+        frame_line = ""
         source_line = ""
+        pre_error = []
         for line in body.splitlines():
             if line.startswith("E "):
                 break
-            if line.strip():
-                source_line = line.strip()
+            pre_error.append(line)
+        for idx, line in enumerate(pre_error):
+            if _TRACEBACK_FRAME.match(line.strip()):
+                frame_line = line.strip().replace("\\", "/")
+                # The source line follows its frame; skip a caret underline.
+                source_line = ""
+                for following in pre_error[idx + 1:]:
+                    stripped = following.strip()
+                    if not stripped or set(stripped) <= {"^", "~"}:
+                        continue
+                    if _TRACEBACK_FRAME.match(stripped):
+                        break
+                    source_line = stripped
+                    break
+        if not frame_line:
+            # Pre-3.11 shape, or a frame-less block: the old rule, minus the
+            # caret case it could never have hit.
+            for line in pre_error:
+                stripped = line.strip()
+                if stripped and not set(stripped) <= {"^", "~"}:
+                    source_line = stripped
 
         signature = "\n".join(error_lines)
         if signature in seen:
@@ -295,6 +329,7 @@ def _extract_traceback_blocks(output: str) -> str:
             continue
         seen[signature] = {
             "tests": [name],
+            "frame": frame_line,
             "source": source_line,
             "errors": error_lines,
         }
@@ -309,6 +344,8 @@ def _extract_traceback_blocks(output: str) -> str:
         if len(tests) > 1:
             header = f"{tests[0]} (and {len(tests) - 1} more with the same error)"
         lines = [header]
+        if entry.get("frame"):
+            lines.append(f"    {entry['frame']}")
         if entry["source"]:
             lines.append(f"    {entry['source']}")
         lines.extend(f"    {e}" for e in entry["errors"])

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8963,
-    "findings_total": 536
+    "sites_examined": 8983,
+    "findings_total": 537
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_failure_attribution_by_frame.py
+++ b/tests/unit/test_failure_attribution_by_frame.py
@@ -1,0 +1,194 @@
+"""A file's fix prompt carries the failures that file owns (#2851).
+
+`run-issue4-120049`, green-loop iteration 1, six files. Every file's edit-script
+prompt carried all four failures under "Fix ALL the failures listed below."
+The one file that owned three of the fixes took 168 s; the files that could
+not do what they were told took 2,022 s, 1,594 s and 1,968 s -- 100k tokens
+of deliberation each, for 1.7 KB patches.
+
+Attribution (`failures_for_file`) existed and never matched, for two reasons
+that compound:
+
+* `_extract_traceback_blocks` kept "the last non-blank line before the E
+  lines" as the source line. On Python 3.11+ that line is the caret underline
+  (`    ^^^^^^^`), not the code. And it never kept the FRAME line --
+  `src\\boostgauge\\collector.py:116: in _is_unleashed_session` -- which is the
+  only line in the block that names the file that raised.
+* `failures_for_file` filtered line by line against forward-slash tokens, and
+  Windows frames carry backslashes.
+
+The fixtures below are pytest's real output from that run, trimmed. The tests
+run the real summariser over it and the real attribution over the summary,
+so the claim "collector.py owns test_req_4 and windows.py owns nothing here"
+is measured on the shape that failed, not on a shape invented to pass.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes import verify_phases
+from assemblyzero.workflows.testing.nodes.implementation import edit_script_fix
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    build_code_edit_script_prompt,
+    failures_for_file,
+    is_attributed,
+)
+
+# pytest --tb=short, Python 3.14, Windows paths. Verbatim from
+# docs/lineage/active/4-testing/007-green-phase.txt of run-issue4-120049,
+# trimmed to two failures and the summary.
+PYTEST_OUTPUT = """\
+============================= test session starts =============================
+collected 12 items
+
+tests/test_issue_4.py::test_req_4 FAILED                                 [ 33%]
+tests/test_issue_4.py::test_req_7 FAILED                                 [ 58%]
+
+================================== FAILURES ===================================
+__________________________________ test_req_4 __________________________________
+tests\\test_issue_4.py:71: in test_req_4
+    assert collector._is_unleashed_session("python.exe", 12345)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+src\\boostgauge\\collector.py:116: in _is_unleashed_session
+    return "unleashed" in name or "unleashed" in cmdline_str
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   TypeError: argument of type 'int' is not a container or iterable
+__________________________________ test_req_7 __________________________________
+tests\\test_issue_4.py:100: in test_req_7
+    assert len(calls) == 1
+E   assert 0 == 1
+E    +  where 0 = len([])
+=========================== short test summary info ===========================
+FAILED tests/test_issue_4.py::test_req_4 - TypeError: argument of type 'int' is not a container or iterable
+FAILED tests/test_issue_4.py::test_req_7 - assert 0 == 1
+========================= 2 failed, 10 passed in 5.85s =========================
+"""
+
+
+@pytest.fixture
+def summary():
+    return verify_phases._build_failure_summary(PYTEST_OUTPUT)
+
+
+class TestTheSummaryCarriesTheFrame:
+    def test_the_innermost_frame_is_kept_with_forward_slashes(self, summary):
+        assert "src/boostgauge/collector.py:116: in _is_unleashed_session" in summary
+
+    def test_the_source_line_is_code_not_carets(self, summary):
+        assert 'return "unleashed" in name or "unleashed" in cmdline_str' in summary
+        for line in summary.splitlines():
+            stripped = line.strip()
+            assert not (stripped and set(stripped) <= {"^"}), (
+                f"a caret underline survived as a 'source line': {line!r}"
+            )
+
+    def test_a_frame_less_block_still_keeps_its_source_line(self, summary):
+        """test_req_7 raises in the test itself; the test frame is its
+        innermost frame and the assertion is its source line."""
+        assert "tests/test_issue_4.py:100: in test_req_7" in summary
+        assert "assert len(calls) == 1" in summary
+
+    def test_the_error_lines_are_unchanged(self, summary):
+        assert "E   TypeError: argument of type 'int' is not a container or iterable" in summary
+        assert "E    +  where 0 = len([])" in summary
+
+
+class TestAttributionOnTheRealShape:
+    def test_the_implementation_file_that_raised_is_attributed(self, summary):
+        assert is_attributed(summary, "src/boostgauge/collector.py")
+
+    def test_a_file_no_failure_names_is_not(self, summary):
+        assert not is_attributed(summary, "src/boostgauge/collectors/windows.py")
+        assert not is_attributed(summary, "tests/integration/test_windows_collector.py")
+        assert not is_attributed(summary, "tests/benchmark/test_windows_collector_bench.py")
+
+    def test_the_scoped_corpus_keeps_whole_blocks(self, summary):
+        scoped = failures_for_file(summary, "src/boostgauge/collector.py")
+        # The frame, its source line and its error travel together.
+        assert "src/boostgauge/collector.py:116: in _is_unleashed_session" in scoped
+        assert 'return "unleashed" in name' in scoped
+        assert "E   TypeError" in scoped
+        # And the failure this file does not own is gone.
+        assert "test_req_7" not in scoped
+
+    def test_the_test_file_owning_a_failure_is_attributed(self, summary):
+        """test_req_7 raises inside tests/test_issue_4.py; the stem token
+        `test_issue_4` names it, so a plan that lists that file gets it."""
+        assert is_attributed(summary, "tests/test_issue_4.py")
+
+    def test_an_unattributable_corpus_is_still_passed_through_whole(self):
+        corpus = "1 test(s): AssertionError\n    e.g. tests/test_x.py::test_y"
+        assert failures_for_file(corpus, "src/boostgauge/collector.py") == corpus
+        assert not is_attributed(corpus, "src/boostgauge/collector.py")
+
+    def test_windows_backslashes_in_the_corpus_match_forward_slash_tokens(self):
+        corpus = (
+            "test_a\n"
+            "    src\\pkg\\mod.py:3: in f\n"
+            "    raise ValueError\n"
+            "    E   ValueError"
+        )
+        assert is_attributed(corpus, "src/pkg/mod.py")
+
+
+class TestThePromptNoLongerOrdersEverythingFixed:
+    def test_the_rule_is_scoped_to_this_files_failures(self):
+        prompt = build_code_edit_script_prompt("src/x.py", "x = 1\n", "E   boom")
+        assert "Fix ALL the failures" not in prompt
+        assert "that this file is responsible for" in prompt
+
+
+class TestTheLoopLeavesUnattributedFilesAlone:
+    """The consequence: with the corpus naming collector.py, windows.py is
+    not called at all. Driven through `implement_code` with the model calls
+    stubbed, so what is asserted is the decision, not the model."""
+
+    def _run(self, tmp_path, summary, capsys):
+        from assemblyzero.workflows.testing.nodes.implementation import orchestrator
+
+        (tmp_path / "src" / "boostgauge" / "collectors").mkdir(parents=True)
+        big = "# " + ("x" * 900) + "\n"  # over MIN_BYTES_FOR_EDIT_SCRIPT
+        (tmp_path / "src" / "boostgauge" / "collector.py").write_text(big, encoding="utf-8")
+        (tmp_path / "src" / "boostgauge" / "collectors" / "windows.py").write_text(big, encoding="utf-8")
+
+        called: list[str] = []
+
+        def fake_edit(filepath, **kwargs):
+            called.append(filepath)
+            return edit_script_fix.EditScriptOutcome(
+                kwargs["existing_content"], failures=[]
+            )
+
+        state = {
+            "repo_root": str(tmp_path),
+            "lld_content": "## 2.1 Files\n",
+            "files_to_modify": [
+                {"path": "src/boostgauge/collector.py", "change_type": "Modify"},
+                {"path": "src/boostgauge/collectors/windows.py", "change_type": "Modify"},
+            ],
+            "test_files": ["tests/test_issue_4.py"],
+            "iteration_count": 1,
+            "test_failure_summary": summary,
+            "audit_dir": str(tmp_path / "audit"),
+        }
+        with patch.object(orchestrator, "try_edit_script_fix", fake_edit), \
+             patch.object(orchestrator, "generate_file_with_retry",
+                          side_effect=AssertionError("full regeneration must not run")), \
+             patch.object(orchestrator, "validate_files_to_modify", return_value=[]), \
+             patch.object(orchestrator, "record_iteration_cost", return_value=0), \
+             patch.object(orchestrator, "get_cumulative_cost", return_value=0.0):
+            try:
+                orchestrator.implement_code(state)
+            except Exception:
+                # Later bookkeeping in the node is not under test; the per-file
+                # decisions have been made and recorded by the time it runs.
+                pass
+        return called, capsys.readouterr().out
+
+    def test_only_the_attributed_file_is_sent_for_a_fix(self, tmp_path, summary, capsys):
+        called, out = self._run(tmp_path, summary, capsys)
+
+        assert called == ["src/boostgauge/collector.py"], called
+        assert "no failure attributed to src/boostgauge/collectors/windows.py" in out
+        assert "failures attributed to 1 of 2 file(s)" in out


### PR DESCRIPTION
## What happened

`run-issue4-120049` (boostgauge #4, resumed from run 15's 48-of-52 state with #2845/#2847 live), green-loop iteration 1, six files:

| file | outcome | duration | output tokens |
|---|---|---|---|
| 1 `src/boostgauge/collector.py` | 5 edits applied | 168 s | 11,094 |
| 2 `src/boostgauge/collectors/windows.py` | 4 edits applied | 2,022 s | 127,003 |
| 3 `tests/unit/test_collector.py` | 4 edits applied | 1,594 s | 97,134 |
| 4 `tests/integration/test_windows_collector.py` | `claude -p` exited 1, empty stderr; fell back to full regeneration (176 s) | 1,968 s | — |

Every file's prompt carried the identical `## FAILING TESTS TO FIX` block — all four failures — under *"Fix ALL the failures listed below. Touch NOTHING else."* The recorded responses for files 2 and 3 are 1,784 and 1,654 bytes. Run 15 had the same shape on the same files, twice hitting the then-20-minute clock; #2843's hour lets each one finish instead.

## Why attribution never fired

`edit_script_fix.failures_for_file` exists to narrow the corpus to the failures a file owns, and falls back to the whole corpus when nothing matches. Nothing ever matched, for two reasons that compound:

1. **The summariser threw away the attributing line and kept the wrong one.** `_extract_traceback_blocks` kept "the last non-blank line before the `E` lines" as the source line. On Python 3.11+ with `--tb=short` that line is the caret underline — the recorded prompt shows `    ^^^^^^^^^^^^^^^^^^^^^^^^^^` where the code should be. And it never kept the *frame* line at all: `src\boostgauge\collector.py:116: in _is_unleashed_session` is in pytest's output (`007-green-phase.txt`) and absent from the prompt (`010-prompt-editscript-…`). That frame is the only line in the block that names the file that raised.
2. **The match was line-by-line against forward-slash tokens**, and Windows frames carry backslashes — so even a frame that survived would not have matched, and a matching line would have been kept without the error under it.

The one fast file is the one where the work was real: `collector.py` owns three of the four fixes. The other five were each told to fix four failures that were not theirs and to change nothing else.

## The change

- **`_extract_traceback_blocks`** keeps the innermost frame (slash-normalised) and the real source line following it, skipping a caret underline. Pre-3.11 output without frames keeps the old rule minus the caret case.
- **`failures_for_file`** attributes per *block*: a column-0 line opens a unit, indented lines continue it, a blank line ends it. One rule reads all three shapes the summary uses — bare `FAILED path::test - reason`, grouped `N test(s): reason` over an indented `e.g.`, and a traceback block — so the frame that names the file and the error it explains are never separated. Lines are slash-normalised before matching. `is_attributed` exposes the yes/no.
- **N4 decides once per iteration.** When the corpus names at least one planned file, a file it does not name is left unchanged with no model call and a log line saying so. When it names none, every file receives the whole corpus, as before — narrowing to nothing is worse than a prompt that is larger than it should be.
- **The prompt** asks for "the failures listed below that this file is responsible for," not "ALL the failures."

The hour-long per-call clock (#2843) stays. A 30-minute productive call must still finish; the fix is to stop asking for unproductive ones.

## Tests

`tests/unit/test_failure_attribution_by_frame.py`, twelve cases, on **pytest's real output from that run** (trimmed to two failures) rather than a shape invented to pass:

- the summary carries `src/boostgauge/collector.py:116: in _is_unleashed_session` and the real source line, and no caret underline survives as a "source line";
- `collector.py` is attributed `test_req_4`; `windows.py`, `test_windows_collector.py` and the benchmark file are attributed nothing; the scoped corpus keeps the frame, source and error together and drops the failure the file does not own;
- Windows backslashes in the corpus match forward-slash tokens; an unattributable corpus still passes through whole;
- driven through `implement_code` with the model stubbed: only `collector.py` is sent for a fix, and the log names the file left alone and the 1-of-2 attribution.

The three pre-existing `TestFailureScoping` cases and `test_the_prompt_is_scoped_to_this_files_failures` — bare `FAILED` lines, no indentation — failed under a first blank-line block rule and pass under the column-0 rule; they are the proof the rule reads that shape too. 105 tests across the eight modules covering the changed code pass.

What the old code produced is on record: the prompt file from the run shows carets and no frame. That artifact is the before; the fixture here is the after.

Closes #2851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
