### PR TITLE
fix: a resume that finds its worktree on disk enters as a later attempt, and a failure raised in a test body is attributed by the names the test uses (Closes #2860, Closes #2861)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1461,6 +1461,22 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     # attempt. Declared out here because a worktree that already exists skips
     # the creation block entirely and still reaches the sub-workflow invoke.
     recovered_branch = ""
+    # #2860: a resume that finds its worktree already on disk is in the same
+    # position as one that recovered it -- the code in it is the prior
+    # attempt's, because a resume exists only after a prior attempt ran. Run
+    # 18 (run-issue4-140813) took this path when the entry sweep could not
+    # remove the previous worktree, entered the sub-workflow as a first
+    # attempt, and the red phase refused the prior work as green-at-red in
+    # three seconds. The signal is "this is a resume", not "this entry ran
+    # `git worktree add`".
+    reused_existing = (
+        state.get("resumed_from") == "impl" and worktree_path.is_dir()
+    )
+    if reused_existing:
+        print(
+            f"    Reusing existing worktree {worktree_path} for the resume "
+            f"(the previous attempt's tree; entering as a later attempt)"
+        )
 
     try:
         # Ensure the worktree exists, carved from the TARGET repo (Issue #1374).
@@ -1723,7 +1739,10 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # iteration_count zero. The recovery would otherwise turn a
             # from-zero rebuild into a halt, which is worse than the defect
             # it fixes.
-            "retry_mode": RESUMED if recovered_branch else state.get("retry_mode", ""),
+            "retry_mode": (
+                RESUMED if (recovered_branch or reused_existing)
+                else state.get("retry_mode", "")
+            ),
             # #2344: seed the iteration cap explicitly. Left absent, each
             # reader fell back to its own inline default -- 5 in N5's progress
             # message, 3 in the router's decision -- so the run announced a

--- a/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
@@ -62,6 +62,7 @@ wrote for the spec stage, and it is what makes this safe to switch on.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -174,8 +175,10 @@ def _file_tokens(filepath: str) -> set[str]:
     }
 
 
-def _attributed_blocks(failure_summary: str, filepath: str) -> list[str]:
-    """The blank-line-separated blocks of the corpus that name this file.
+def _attributed_blocks(
+    failure_summary: str, filepath: str, repo_root: Path | None = None,
+) -> list[str]:
+    """The blocks of the corpus that name this file.
 
     #2851: attribution is per BLOCK, not per line. A traceback block is a test
     name, a frame, a source line and its `E` lines; the frame is the line that
@@ -184,16 +187,121 @@ def _attributed_blocks(failure_summary: str, filepath: str) -> list[str]:
     filename with no error under it. Lines are slash-normalised before the
     match because pytest prints Windows frames with backslashes and the tokens
     are built with forward slashes.
+
+    #2861: a block the frame rule leaves unattributed, whose innermost frame
+    is a TEST function, is attributed by what that test's body names. An
+    assertion that raises in the test itself (`assert len(calls) == 1`) has
+    no frame under src/, but the test constructed `WindowsCollector({})` and
+    called `.collect()`, and the planned file that defines those names is the
+    file the failure is about. Needs `repo_root` to read the test; without it
+    the frame rule stands alone, as before.
     """
     tokens = _file_tokens(filepath)
     if not tokens:
         return []
+    defined: set[str] | None = None  # parsed lazily, once per file
     kept: list[str] = []
     for block in _blocks(failure_summary):
         haystack = block.replace("\\", "/").lower()
         if any(token in haystack for token in tokens):
             kept.append(block)
+            continue
+        if repo_root is None:
+            continue
+        test_ref = _test_frame_of(block)
+        if test_ref is None:
+            continue
+        if defined is None:
+            defined = _names_defined_in(repo_root / filepath)
+        if not defined:
+            continue
+        used = _names_used_by_test(repo_root / test_ref[0], test_ref[1])
+        if used & defined:
+            kept.append(block)
     return kept
+
+
+def _test_frame_of(block: str) -> tuple[str, str] | None:
+    """(test file path, test function name) from a block's innermost frame,
+    or None when the innermost frame is not a test function."""
+    frame = None
+    for line in block.splitlines():
+        match = _FRAME.match(line.strip().replace("\\", "/"))
+        if match:
+            frame = match
+    if frame is None:
+        return None
+    path, func = frame.group(1), frame.group(2)
+    if not (Path(path).name.startswith("test_") or func.startswith("test_")):
+        return None
+    return path, func
+
+
+#: `path/to/file.py:116: in some_function`, forward slashes, stripped.
+_FRAME = re.compile(r"^(\S+?\.py):\d+: in (\S+)")
+
+#: Names too generic to attribute on: a test that calls `run()` or reads
+#: `.name` says nothing about which planned file it exercises.
+_MIN_NAME_LEN = 4
+
+
+def _names_defined_in(path: Path) -> set[str]:
+    """Top-level classes and functions, and the methods of top-level classes."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, ValueError):
+        # fail-open: a planned file that cannot be parsed defines nothing
+        # this rule can see, so the block stays unattributed to it and the
+        # frame rule and the whole-corpus fallback decide -- which is exactly
+        # the behaviour before #2861. Attributing on a guess is the failure.
+        return set()
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            names.add(node.name)
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    names.add(item.name)
+    return {
+        n for n in names
+        if len(n) >= _MIN_NAME_LEN and not (n.startswith("__") and n.endswith("__"))
+    }
+
+
+def _names_used_by_test(path: Path, func: str) -> set[str]:
+    """Every Name and Attribute the named test function's body refers to."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, ValueError):
+        # fail-open: same reasoning as `_names_defined_in` -- an unreadable
+        # test attributes nothing by this rule, and the earlier rules stand.
+        return set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == func
+        ):
+            # Names the test BINDS itself -- locals, its own helpers, its
+            # parameters -- are not references to anything a planned file
+            # defines. `start = time.process_time()` in test_req_8 must not
+            # attribute a planned file that happens to define `start()`.
+            bound: set[str] = {a.arg for a in ast.walk(node.args) if isinstance(a, ast.arg)}
+            used: set[str] = set()
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Name):
+                    if isinstance(sub.ctx, ast.Load):
+                        used.add(sub.id)
+                    else:
+                        bound.add(sub.id)
+                elif isinstance(sub, ast.Attribute):
+                    used.add(sub.attr)
+                elif isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    if sub is not node:
+                        bound.add(sub.name)
+            return {n for n in used - bound if len(n) >= _MIN_NAME_LEN}
+    return set()
 
 
 def _blocks(failure_summary: str) -> list[str]:
@@ -223,17 +331,23 @@ def _blocks(failure_summary: str) -> list[str]:
     return blocks
 
 
-def is_attributed(failure_summary: str, filepath: str) -> bool:
+def is_attributed(
+    failure_summary: str, filepath: str, repo_root: Path | None = None,
+) -> bool:
     """Does at least one failure in the corpus name this file?
 
     The caller's decision (#2851): when the corpus attributes to SOME file,
     a file it does not attribute to has nothing to fix this iteration and is
     left alone -- not sent the whole corpus with an order to fix all of it.
+    With `repo_root`, a failure raised inside a test body is attributed by
+    the names that test uses (#2861).
     """
-    return bool(_attributed_blocks(failure_summary, filepath))
+    return bool(_attributed_blocks(failure_summary, filepath, repo_root))
 
 
-def failures_for_file(failure_summary: str, filepath: str) -> str:
+def failures_for_file(
+    failure_summary: str, filepath: str, repo_root: Path | None = None,
+) -> str:
     """The failures this file is implicated in, or everything if unattributable.
 
     The issue asks to "scope the prompt to the failing tests rather than the
@@ -252,7 +366,7 @@ def failures_for_file(failure_summary: str, filepath: str) -> str:
     """
     if not failure_summary.strip():
         return failure_summary
-    kept = _attributed_blocks(failure_summary, filepath)
+    kept = _attributed_blocks(failure_summary, filepath, repo_root)
     if not kept:
         return failure_summary
     return "\n\n".join(kept)

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -724,9 +724,11 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
     # prompt that is larger than it should be.
     attributed_paths: set[str] = set()
     if revision_error_context:
+        # #2861: with repo_root, a failure raised inside a test body is
+        # attributed by the names the test uses, not only by its frames.
         attributed_paths = {
             spec["path"] for spec in files_to_modify
-            if is_attributed(revision_error_context, spec["path"])
+            if is_attributed(revision_error_context, spec["path"], repo_root)
         }
         if attributed_paths:
             print(
@@ -736,8 +738,8 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             )
         else:
             print(
-                "    [N4] failures attributed to no file by traceback; every "
-                "file receives the whole failure set"
+                "    [N4] failures attributed to no file by traceback or "
+                "test body; every file receives the whole failure set"
             )
 
     for i, file_spec in enumerate(files_to_modify):

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 8983,
-    "findings_total": 537
+    "sites_examined": 9011,
+    "findings_total": 539
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_failure_attribution_by_test_body.py
+++ b/tests/unit/test_failure_attribution_by_test_body.py
@@ -1,0 +1,183 @@
+"""A failure raised inside a test body is attributed by the names the test
+uses (#2861).
+
+`run-issue4-141013`, green-loop iteration 2, the two failures left:
+
+    test_req_7
+        tests/test_issue_4.py:100: in test_req_7
+        assert len(calls) == 1
+        E   assert 0 == 1
+
+    test_req_8
+        tests/test_issue_4.py:111: in test_req_8
+        assert (time.process_time() - start) / 8.0 < 0.020
+        E   AssertionError: ...
+
+Both raise in the test itself, so the innermost frame is the test file and
+the #2851 frame rule matches no planned file -- N4 printed `failures
+attributed to no file by traceback` and every file received the whole corpus.
+The test bodies say what they exercise: `WindowsCollector({})` and
+`.collect()`. The planned files that define those names are the ones the
+failures are about.
+
+The repository here is a real temporary tree with the same shape: a test
+file whose functions raise in their own bodies, two source files that define
+`WindowsCollector`/`collect`, and a planned test file that defines only
+`test_*` functions.
+"""
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    failures_for_file,
+    is_attributed,
+)
+
+CORPUS = """\
+test_req_7
+    tests/test_issue_4.py:100: in test_req_7
+    assert len(calls) == 1
+    E   assert 0 == 1
+    E    +  where 0 = len([])
+
+test_req_8
+    tests/test_issue_4.py:111: in test_req_8
+    assert (time.process_time() - start) / 8.0 < 0.020
+    E   AssertionError: assert ((3.84375 - 1.71875) / 8.0) < 0.02
+"""
+
+TEST_FILE = '''\
+from boostgauge.collector import *  # noqa: F401, F403
+
+
+def test_req_7(monkeypatch):
+    import ctypes
+    calls = []
+    def mock_query(*args):
+        calls.append(1)
+        return 0
+    monkeypatch.setattr(ctypes.windll.ntdll, "NtQuerySystemInformation", mock_query)
+    collector = WindowsCollector({})
+    collector.collect()
+    assert len(calls) == 1
+
+
+def test_req_8():
+    import time
+    collector = WindowsCollector({})
+    collector.collect()
+    start = time.process_time()
+    for _ in range(8):
+        collector.collect()
+    assert (time.process_time() - start) / 8.0 < 0.020
+'''
+
+WINDOWS_PY = '''\
+class WindowsCollector:
+    def collect(self):
+        return self._sweep()
+
+    def _sweep(self):
+        return (0, 0, 0, 0)
+'''
+
+COLLECTOR_PY = '''\
+class DataCollector:
+    def start(self):
+        pass
+
+
+class SystemSnapshot:
+    pass
+'''
+
+PLANNED_TEST_PY = '''\
+def test_collector_starts():
+    assert True
+'''
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "src" / "boostgauge" / "collectors").mkdir(parents=True)
+    (tmp_path / "tests" / "test_issue_4.py").write_text(TEST_FILE, encoding="utf-8")
+    (tmp_path / "tests" / "test_collector.py").write_text(PLANNED_TEST_PY, encoding="utf-8")
+    (tmp_path / "src" / "boostgauge" / "collectors" / "windows.py").write_text(
+        WINDOWS_PY, encoding="utf-8"
+    )
+    (tmp_path / "src" / "boostgauge" / "collector.py").write_text(
+        COLLECTOR_PY, encoding="utf-8"
+    )
+    return tmp_path
+
+
+class TestAttributionByWhatTheTestUses:
+    def test_the_file_defining_the_class_the_test_constructs_is_attributed(self, repo):
+        assert is_attributed(CORPUS, "src/boostgauge/collectors/windows.py", repo)
+
+    def test_a_source_file_the_test_never_touches_is_not(self, repo):
+        """collector.py defines DataCollector, SystemSnapshot and a `start`
+        method. Neither test names the classes, and `start` in test_req_8 is
+        a LOCAL the test assigns (`start = time.process_time()`) -- a name the
+        test binds itself is not a reference to anything a planned file
+        defines, and must not attribute one."""
+        assert not is_attributed(CORPUS, "src/boostgauge/collector.py", repo)
+
+    def test_a_planned_test_file_is_not_attributed_by_another_tests_body(self, repo):
+        assert not is_attributed(CORPUS, "tests/test_collector.py", repo)
+
+    def test_both_blocks_travel_to_the_attributed_file(self, repo):
+        scoped = failures_for_file(CORPUS, "src/boostgauge/collectors/windows.py", repo)
+        assert "test_req_7" in scoped and "test_req_8" in scoped
+        assert "E   assert 0 == 1" in scoped
+
+    def test_without_a_repo_root_the_frame_rule_stands_alone(self):
+        """Callers that cannot read the tree keep #2851's behaviour exactly."""
+        assert not is_attributed(CORPUS, "src/boostgauge/collectors/windows.py")
+        assert failures_for_file(CORPUS, "src/boostgauge/collectors/windows.py") == CORPUS
+
+
+class TestTheRuleStaysConservative:
+    def test_a_short_common_name_does_not_attribute(self, repo):
+        """`run`, `get`, `name` -- three letters or a bare attribute -- say
+        nothing about which planned file a test exercises."""
+        (repo / "src" / "boostgauge" / "misc.py").write_text(
+            "def run():\n    pass\n\n\ndef len():\n    pass\n", encoding="utf-8"
+        )
+        assert not is_attributed(CORPUS, "src/boostgauge/misc.py", repo)
+
+    def test_a_block_whose_frame_is_not_a_test_uses_the_frame_rule_only(self, repo):
+        corpus = (
+            "test_x\n"
+            "    src/boostgauge/collector.py:12: in start\n"
+            "    raise ValueError\n"
+            "    E   ValueError"
+        )
+        assert is_attributed(corpus, "src/boostgauge/collector.py", repo)
+        assert not is_attributed(corpus, "src/boostgauge/collectors/windows.py", repo)
+
+    def test_an_unparseable_planned_file_attributes_nothing(self, repo):
+        (repo / "src" / "boostgauge" / "broken.py").write_text(
+            "def (:\n", encoding="utf-8"
+        )
+        assert not is_attributed(CORPUS, "src/boostgauge/broken.py", repo)
+
+    def test_a_missing_test_file_attributes_nothing(self, repo):
+        corpus = CORPUS.replace("tests/test_issue_4.py", "tests/test_gone.py")
+        assert not is_attributed(corpus, "src/boostgauge/collectors/windows.py", repo)
+
+
+class TestTheFrameRuleStillWinsFirst:
+    def test_a_src_frame_attributes_without_reading_any_test(self, repo, monkeypatch):
+        """The identifier rule is consulted only for blocks the frame rule
+        left unattributed; a block the frame names must not depend on the
+        test file being readable."""
+        corpus = (
+            "test_req_4\n"
+            "    src/boostgauge/collector.py:116: in _is_unleashed_session\n"
+            "    return 'unleashed' in name\n"
+            "    E   TypeError: argument of type 'int' is not a container"
+        )
+        (repo / "tests" / "test_issue_4.py").unlink()
+        assert is_attributed(corpus, "src/boostgauge/collector.py", repo)

--- a/tests/unit/test_impl_resume_reuses_existing_worktree.py
+++ b/tests/unit/test_impl_resume_reuses_existing_worktree.py
@@ -1,0 +1,100 @@
+"""A resume that finds its worktree on disk enters as a later attempt (#2860).
+
+`run-issue4-140813`: the entry sweep could not remove the previous attempt's
+worktree (Permission denied, holder unidentified), so `run_impl_stage` found
+`worktree_path.is_dir()` true, skipped creation, and ran the sub-workflow
+against the prior attempt's tree -- as a FIRST attempt. #2845 sent RESUMED
+only when this entry had carved the worktree from a grave. The red phase read
+the surviving implementation as green-at-red and halted in three seconds.
+
+Same harness as `test_impl_resume_from_preserved_attempt.py`: the payload
+`run_impl_stage` hands `app.invoke` is what is under test.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core.retry_mode import RESUMED
+from assemblyzero.workflows.orchestrator import stages
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    # mock-ok: subprocess boundary, and a REAL CompletedProcess (standard 0024).
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _quiet_git(cmd, *args, **kwargs):
+    return _completed()
+
+
+@pytest.fixture
+def state(tmp_path):
+    target = tmp_path / "targetrepo"
+    target.mkdir()
+    return {
+        "issue_number": 4,
+        "target_repo": str(target),
+        "assemblyzero_root": str(tmp_path / "az"),
+        "base_branch": "hardening-run-20",
+        "retry_mode": "",
+    }
+
+
+def _payload(state, worktree_exists: bool):
+    seen: dict = {}
+
+    class _App:
+        def invoke(self, payload, config=None):
+            seen.update(payload)
+            raise RuntimeError("stop here: the payload is what is under test")
+
+    class _Graph:
+        def compile(self):
+            return _App()
+
+    with patch.object(stages, "run_command", _quiet_git), \
+         patch.object(Path, "is_dir", return_value=worktree_exists), \
+         patch.object(Path, "is_file", return_value=False), \
+         patch(
+             "assemblyzero.workflows.testing.graph.build_testing_workflow",
+             return_value=_Graph(),
+         ):
+        try:
+            stages.run_impl_stage(state)
+        except Exception:
+            pass
+    assert seen, "run_impl_stage never reached app.invoke"
+    return seen
+
+
+class TestAnExistingWorktreeOnAResume:
+    def test_enters_as_RESUMED(self, state):
+        state["resumed_from"] = "impl"
+
+        assert _payload(state, worktree_exists=True).get("retry_mode") == RESUMED
+
+    def test_is_named_in_the_log(self, state, capsys):
+        state["resumed_from"] = "impl"
+
+        _payload(state, worktree_exists=True)
+
+        assert "Reusing existing worktree" in capsys.readouterr().out
+
+
+class TestTheSignalIsStillScopedToResumes:
+    def test_a_fresh_draw_with_a_leftover_worktree_keeps_the_states_mode(self, state):
+        """A first run whose worktree somehow pre-exists is not a resume, and
+        #2337's green-at-red guard must still be able to fire for it."""
+        state["resumed_from"] = ""
+
+        assert _payload(state, worktree_exists=True).get("retry_mode") == ""
+
+    def test_a_resume_into_another_stage_is_untouched(self, state):
+        state["resumed_from"] = "spec"
+
+        assert _payload(state, worktree_exists=True).get("retry_mode") == ""


### PR DESCRIPTION
Two gaps left by this morning's fixes (#2845, #2851), each measured on the run that exposed it. Both are on the same two files and the same resume path, so one PR.

## #2860 — a resume that finds its worktree on disk enters as a first attempt

`run-issue4-140813` (14:08). The entry sweep could not remove the previous attempt's worktree — `git declined to remove it: ... Permission denied` — and the sweep already clears ReadOnly and retries, so this was a held handle seven minutes after the kill; the holder is not identified, and RESTORE removed the same tree three seconds later. `run_impl_stage` found `worktree_path.is_dir()` true, skipped creation, and ran the sub-workflow against the prior attempt's tree. #2845 sends `RESUMED` only when *this entry carved* the worktree from a grave, so the sub-workflow entered as a first attempt, and the red phase halted on `6 passed` as green-at-red. Three seconds.

**Change.** On `resumed_from == "impl"`, the sub-workflow enters as `RESUMED` whether the worktree was recovered or found. The signal means "this is a resume," not "this entry ran `git worktree add`." The reuse is named in the log. A fresh draw that somehow finds a leftover worktree keeps the state's own mode, so #2337's guard still fires there.

## #2861 — a failure raised inside the test body is attributed by what the test uses

`run-issue4-141013` (14:10), iteration 2, two failures left:

```
test_req_7
    tests/test_issue_4.py:100: in test_req_7
    assert len(calls) == 1
    E   assert 0 == 1

test_req_8
    tests/test_issue_4.py:111: in test_req_8
    assert (time.process_time() - start) / 8.0 < 0.020
    E   AssertionError: assert ((3.84375 - 1.71875) / 8.0) < 0.02
```

Both raise in the test itself. The innermost frame is the test file, so #2851's frame rule matched no planned file; N4 printed `failures attributed to no file by traceback; every file receives the whole failure set`, and iteration 2 took the path #2851 exists to close.

The test bodies name what they exercise: `WindowsCollector({})`, `.collect()`. The planned source files define those names; the four planned test files define only `test_*` functions.

**Change.** A block the frame rule leaves unattributed, whose innermost frame is a test function, is attributed by intersecting the identifiers that test's body uses (`ast.Name`, `ast.Attribute`) with the names each planned file defines at top level, including the methods of its top-level classes. Conservative on purpose: defined names only, never the corpus text; four characters or more; dunders excluded; an unparseable planned file or a missing test file attributes nothing by this rule (declared `# fail-open:`, since the frame rule and the whole-corpus fallback still decide). The frame rule runs first. Callers without a `repo_root` keep #2851's behaviour exactly.

## Tests

`test_impl_resume_reuses_existing_worktree.py` (4): the existing-worktree path on a resume sends `RESUMED` and names the reuse; a fresh draw with a leftover worktree keeps the state's mode; a resume into another stage is untouched.

`test_failure_attribution_by_test_body.py` (10), on a real temporary tree shaped like the run — the two blocks above verbatim, a test file whose functions raise in their own bodies, two source files, a planned test file: `windows.py` is attributed (it defines `WindowsCollector`/`collect`); a source file the tests never touch is not; a planned test file is not attributed by another test's body; both blocks travel to the attributed file; no `repo_root` means the frame rule stands alone; a short common name (`run`, `len`) does not attribute; a non-test frame uses the frame rule only; an unparseable planned file and a missing test file attribute nothing; and a `src/` frame attributes without reading any test.

Neighbouring suites (frame attribution, edit-script fix, preserved-attempt resume, invoke payload, worktree base, failure feedback ×3, mid-arc edit script, freeze-tests, implement-code timeout) below.

Closes #2860
Closes #2861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
