### PR TITLE
fix: an ordered --kill disposes the attempt branch it orphaned, so the resume it promises can happen (Closes #2859)

### DIFF
--- a/tests/unit/test_kill_disposes_the_attempt_branch.py
+++ b/tests/unit/test_kill_disposes_the_attempt_branch.py
@@ -1,0 +1,153 @@
+"""An ordered stop disposes the attempt branch, so the resume it promises can
+happen (#2859).
+
+`--kill` tree-kills the roll, which skips RESTORE's `finally`. On 2026-09-05
+that left `issue-4` standing at the run's last checkpoint. The launcher's entry
+sweep removes worktrees and not branches; the next launch's impl stage then
+refuses a leftover `issue-N` that carries commits (#2310), and #2845's
+recovery looks only under `graveyard/`. The stop had printed "the next launch
+resumes from where this one stopped", and the launch that followed halted in
+three seconds. The branch was renamed by hand that day.
+
+The first class runs against a REAL git repository: a base branch, an attempt
+branch with a checkpoint on it, a registered worktree. The kill itself is
+stubbed at the process boundary, as the sibling kill tests do; everything git
+does is real, because the claim is about what git is left holding.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """main with one commit; issue-1 with one checkpoint; a worktree on issue-1."""
+    r = tmp_path / "campaign"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "T")
+    (r / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(r, "add", "base.txt")
+    _git(r, "commit", "-m", "base")
+    (r / "data" / "speedrun" / "runs").mkdir(parents=True)
+    _git(r, "worktree", "add", str(r / "data" / "worktrees" / "1"), "-b", "issue-1", "main")
+    wt = r / "data" / "worktrees" / "1"
+    (wt / "impl.py").write_text("x = 1\n", encoding="utf-8")
+    _git(wt, "add", "impl.py")
+    _git(wt, "commit", "-m", "[CP:post-impl] issue #1: workflow checkpoint")
+    return r
+
+
+@pytest.fixture
+def log_dir(repo):
+    return repo / "data" / "speedrun" / "runs"
+
+
+def _kill(repo, log_dir, issue=1):
+    sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+    patches = [
+        patch.object(sr, "is_live_python", return_value=True),
+        patch.object(sr, "tree_kill", return_value=(True, "")),
+        patch.object(sr, "_active_run_event_logs", return_value=[]),
+    ]
+    if sys.platform == "win32":
+        patches.append(patch.object(sr, "_end_task_for", return_value=(False, "no task")))
+    for p in patches:
+        p.start()
+    try:
+        return sr.kill_roll(repo, log_dir, issue)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestTheAttemptBranchIsDisposed:
+    def test_issue_branch_is_gone_and_its_checkpoint_is_under_graveyard(self, repo, log_dir, capsys):
+        tip = _git(repo, "rev-parse", "issue-1")
+
+        code = _kill(repo, log_dir)
+
+        assert code == 0
+        branches = _git(repo, "branch", "--list", "--format=%(refname:short)").splitlines()
+        assert "issue-1" not in branches, branches
+        graves = [b for b in branches if b.startswith("graveyard/issue-1-")]
+        assert len(graves) == 1, branches
+        assert _git(repo, "rev-parse", graves[0]) == tip, "the checkpoint must survive at the same SHA"
+        assert "the next launch recovers it" in capsys.readouterr().out
+
+    def test_the_worktree_is_removed(self, repo, log_dir):
+        _kill(repo, log_dir)
+
+        listed = _git(repo, "worktree", "list", "--porcelain")
+        assert "data/worktrees/1" not in listed.replace("\\", "/"), listed
+
+    def test_a_branch_with_nothing_unique_is_freed_not_preserved(self, repo, log_dir):
+        """#2310's other disposition: pointer-identical to the base means the
+        name is simply freed, and no grave is made for nothing."""
+        # Rewind issue-1 to main by recreating it empty.
+        _git(repo, "worktree", "remove", str(repo / "data" / "worktrees" / "1"))
+        _git(repo, "branch", "-m", "issue-1", "graveyard/issue-1-earlier")
+        _git(repo, "branch", "issue-1", "main")
+
+        _kill(repo, log_dir)
+
+        branches = _git(repo, "branch", "--list", "--format=%(refname:short)").splitlines()
+        assert "issue-1" not in branches
+        assert [b for b in branches if b.startswith("graveyard/issue-1-")] == [
+            "graveyard/issue-1-earlier"
+        ]
+
+
+class TestNothingIsDisposedUnlessATreeWasKilled:
+    def test_a_stale_pid_leaves_the_branch_alone(self, repo, log_dir):
+        sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+        with patch.object(sr, "is_live_python", return_value=False), \
+             patch.object(sr, "tree_kill", return_value=(True, "")), \
+             patch.object(sr, "_active_run_event_logs", return_value=[]):
+            sr.kill_roll(repo, log_dir, 1)
+
+        branches = _git(repo, "branch", "--list", "--format=%(refname:short)").splitlines()
+        assert "issue-1" in branches
+
+    def test_no_issue_named_means_no_disposal(self, repo, log_dir, capsys):
+        _kill(repo, log_dir, issue=None)
+
+        branches = _git(repo, "branch", "--list", "--format=%(refname:short)").splitlines()
+        assert "issue-1" in branches
+        assert "no issue named" in capsys.readouterr().out
+
+
+class TestACleanupFailureDoesNotFailTheStop:
+    def test_a_repo_git_cannot_read_still_reports_a_successful_stop(self, tmp_path, capsys):
+        """The sibling kill tests use a bare `.git` directory and patch
+        `sr._run`; disposal runs real git through `speedrun_reset`, which
+        must report rather than raise on such a tree."""
+        fake = tmp_path / "boostgauge"
+        (fake / ".git").mkdir(parents=True)
+        log_dir = fake / "data" / "speedrun" / "runs"
+        log_dir.mkdir(parents=True)
+
+        code = _kill(fake, log_dir)
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "This was an ordered stop" in out

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1918,6 +1918,20 @@ def kill_roll(repo_root: Path, log_dir: Path, issue: int | None) -> int:
         _ended, outcome = _end_task_for(repo_root)
         print(f"  {outcome}")
 
+    # #2859: a tree-kill skips RESTORE's `finally`, so the attempt branch
+    # `issue-N` was left standing at its last checkpoint -- and the next
+    # launch's impl stage refuses a leftover branch that carries commits
+    # (#2310), while #2845's recovery looks only under graveyard/. On
+    # 2026-09-05 the stop below promised "the next launch resumes from where
+    # this one stopped" and the launch that followed halted in three seconds
+    # on the leftover name. The RESTORE tail this kill prevented runs here
+    # instead: the worktree is removed when git will let it go, and the branch
+    # is disposed by the #2310 rule -- renamed under graveyard/ when it holds
+    # work, safe-deleted when it holds nothing -- so the resume finds it.
+    disposed = _dispose_after_kill(repo_root, issue) if killed else []
+    for line in disposed:
+        print(f"  {line}")
+
     if stamped:
         print(f"Stamped '{KILLED_MARKER}' into {len(stamped)} run log(s).")
     print(
@@ -1925,6 +1939,41 @@ def kill_roll(repo_root: Path, log_dir: Path, issue: int | None) -> int:
         "are preserved;\n  the next launch resumes from where this one stopped."
     )
     return 0
+
+
+def _dispose_after_kill(repo_root: Path, issue: int | None) -> list[str]:
+    """RESTORE's worktree-and-branch tail, for a stop that skipped RESTORE.
+
+    Returns the lines to print. Never raises: the kill has already happened,
+    and a cleanup that cannot run is reported, not turned into a failed stop.
+    """
+    if issue is None:
+        return ["no issue named; attempt branches left as they are"]
+    lines: list[str] = []
+    try:
+        if reset.remove_worktree(repo_root, issue):
+            lines.append(f"Removed the worktree for #{issue}.")
+        base = attempt.default_branch(repo_root)
+        failures = reset.dispose_pipeline_branches(repo_root, issue, base)
+        for failure in failures:
+            lines.append(f"branch not disposed: {failure}")
+        if not failures:
+            lines.append(
+                f"Attempt branch for #{issue} disposed (preserved under "
+                f"graveyard/ if it held work); the next launch recovers it."
+            )
+    except Exception as exc:  # noqa: BLE001 - the stop has happened; report
+        # fail-open: the operator's order -- stop the roll -- is already
+        # carried out above. A failure in the tidy-up that follows is named
+        # here so the operator knows the branch may still be standing; turning
+        # it into a non-zero exit would report a stop that succeeded as one
+        # that failed, which is the confusion #2422's stamp exists to prevent.
+        lines.append(
+            f"could not dispose #{issue}'s worktree/branch ({exc}); if "
+            f"`issue-{issue}` is still standing, rename it under graveyard/ "
+            f"before relaunching"
+        )
+    return lines
 
 
 # =============================================================================


### PR DESCRIPTION
## What happened

`speedrun_roll.py --kill --issue 4` on `run-issue4-120049` (2026-09-05 14:01). It ended the process tree and printed:

```
This was an ordered stop, not a failure. The stages that passed are preserved;
the next launch resumes from where this one stopped.
```

A tree-kill skips RESTORE's `finally` (the RESTORE docstring says so). After the stop, boostgauge held the branch `issue-4` at `a7a387e` — seven commits beyond the base, the newest a `[CP:post-impl]` checkpoint from that run's iteration 1 — and no new graveyard branch. The entry sweep at the next launch removes worktrees and not branches (`sweep_pipeline_worktrees` never calls `dispose_pipeline_branches`; only RESTORE does). So the next launch would have reached `run_impl_stage` with `issue-4` standing, the #2310 leftover check would have measured seven unique commits and raised, and #2845's recovery — which looks only under `graveyard/` — would have offered the *older* grave. Iteration 1's work sat on a branch nothing would read. It was renamed by hand.

## The change

`kill_roll` runs RESTORE's worktree-and-branch tail after a successful tree-kill, in a helper that never raises:

- the worktree is removed when git will let it go (`reset.remove_worktree`, which never force-removes and never deletes a dirty tree);
- the branch is disposed by the #2310 rule (`reset.dispose_pipeline_branches`): renamed under `graveyard/` when it holds work, safe-deleted when it is pointer-identical to the base, never a force delete;
- what happened is printed before the closing message, so "the next launch resumes from where this one stopped" is a report, not a hope.

Nothing is disposed unless a tree was actually killed and an issue was named. A failure in the tidy-up is reported with the by-hand remedy, never turned into a non-zero exit: the operator's order was carried out the moment the tree died, and a stop that succeeded must not read as one that failed.

If a handle is still held when the stop runs (run 18's `Permission denied` seven minutes after a kill — holder unidentified), the worktree removal is refused and reported, the rename still frees the name and keeps the commits, and the next launch's sweep takes the worktree; the impl stage then recovers from the grave or, under #2860, reuses the worktree as a later attempt.

## Tests

`tests/unit/test_kill_disposes_the_attempt_branch.py`, six cases, against a **real git repository** (base branch, attempt branch carrying a checkpoint, registered worktree) with only the process boundary stubbed — `is_live_python`, `tree_kill`, the events-log stamp, and on Windows `_end_task_for`. Everything git does is real, because the claim is about what git is left holding.

- the checkpoint survives under `graveyard/issue-1-<stamp>` at the same SHA and `issue-1` is gone; the log says the next launch recovers it;
- the worktree is removed;
- a pointer-identical branch is freed, not preserved (no grave made for nothing);
- a stale pid disposes nothing; no issue named disposes nothing;
- the sibling kill tests' bare-`.git` fixture, which real git cannot read, still reports a successful stop.

The sibling kill suites (`test_speedrun_roll_kill.py`, `test_kill_ends_only_its_own_task.py`, `test_emergency_stop_windows_paths.py`) exercise the real task-end path; they were run after the live roll on this machine had stopped, per the standing rule, and the result is in the merge comment.

Closes #2859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
