### PR TITLE
fix: a method name attributes a planned file only when the test also uses the class that defines it (Closes #2865)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
@@ -199,7 +199,7 @@ def _attributed_blocks(
     tokens = _file_tokens(filepath)
     if not tokens:
         return []
-    defined: set[str] | None = None  # parsed lazily, once per file
+    defined: tuple[set[str], dict[str, set[str]]] | None = None  # parsed once per file
     kept: list[str] = []
     for block in _blocks(failure_summary):
         haystack = block.replace("\\", "/").lower()
@@ -213,10 +213,17 @@ def _attributed_blocks(
             continue
         if defined is None:
             defined = _names_defined_in(repo_root / filepath)
-        if not defined:
+        top, methods = defined
+        if not top and not methods:
             continue
         used = _names_used_by_test(repo_root / test_ref[0], test_ref[1])
-        if used & defined:
+        # #2865: a top-level name the test uses is enough. A method name
+        # counts only when the test also uses a class that defines it -- so
+        # `collect` attributes the file whose WindowsCollector defines it,
+        # and not a file whose `collect` hangs off a DummyCollector double.
+        if used & top or any(
+            methods[m] & used for m in used if m in methods
+        ):
             kept.append(block)
     return kept
 
@@ -245,8 +252,16 @@ _FRAME = re.compile(r"^(\S+?\.py):\d+: in (\S+)")
 _MIN_NAME_LEN = 4
 
 
-def _names_defined_in(path: Path) -> set[str]:
-    """Top-level classes and functions, and the methods of top-level classes."""
+def _names_defined_in(path: Path) -> tuple[set[str], dict[str, set[str]]]:
+    """(top-level classes and functions, {method name: classes defining it}).
+
+    #2865: the two are kept apart because they are different strengths of
+    evidence. A top-level name the test uses says which file it exercises.
+    A method name says so only together with its class: on run-issue4-151141
+    the failing tests' `collector.collect()` matched the `collect` method of a
+    `DummyCollector` test double in two planned test files, and both were
+    sent for a fix that was not theirs.
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, ValueError):
@@ -254,20 +269,26 @@ def _names_defined_in(path: Path) -> set[str]:
         # this rule can see, so the block stays unattributed to it and the
         # frame rule and the whole-corpus fallback decide -- which is exactly
         # the behaviour before #2861. Attributing on a guess is the failure.
-        return set()
-    names: set[str] = set()
+        return set(), {}
+
+    def _ok(name: str) -> bool:
+        return len(name) >= _MIN_NAME_LEN and not (
+            name.startswith("__") and name.endswith("__")
+        )
+
+    top: set[str] = set()
+    methods: dict[str, set[str]] = {}
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            names.add(node.name)
+            if _ok(node.name):
+                top.add(node.name)
         elif isinstance(node, ast.ClassDef):
-            names.add(node.name)
+            if _ok(node.name):
+                top.add(node.name)
             for item in node.body:
-                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    names.add(item.name)
-    return {
-        n for n in names
-        if len(n) >= _MIN_NAME_LEN and not (n.startswith("__") and n.endswith("__"))
-    }
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and _ok(item.name):
+                    methods.setdefault(item.name, set()).add(node.name)
+    return top, methods
 
 
 def _names_used_by_test(path: Path, func: str) -> set[str]:

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 9013,
+    "sites_examined": 9016,
     "findings_total": 540
   },
   "undeclared": [

--- a/tests/unit/test_failure_attribution_method_names.py
+++ b/tests/unit/test_failure_attribution_method_names.py
@@ -1,0 +1,130 @@
+"""A method name attributes a planned file only when its class is used too
+(#2865).
+
+`run-issue4-151141`, iteration 3:
+
+    [N4] failures attributed to 4 of 6 file(s): src/boostgauge/collector.py,
+    src/boostgauge/collectors/windows.py,
+    tests/benchmark/test_windows_collector_bench.py, tests/unit/test_collector.py
+
+The two source files were right: they define `WindowsCollector`, which the
+failing tests construct. The two test files were wrong: each defines a test
+double, `DummyCollector`, with a `collect` method, and the failing tests call
+`collector.collect()`. #2861 counted a method of a top-level class as a
+defined name, so a method name shared with a double attributed the double's
+file. Six files became four instead of two.
+
+The rule now: a top-level class or function the test uses attributes the
+file that defines it; a METHOD name is evidence only when the class that
+defines it is itself among the names the test uses.
+"""
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    is_attributed,
+)
+
+CORPUS = """\
+test_req_7
+    tests/test_issue_4.py:100: in test_req_7
+    assert len(calls) == 1
+    E   assert 0 == 1
+
+test_req_8
+    tests/test_issue_4.py:111: in test_req_8
+    assert (time.process_time() - start) / 8.0 < 0.020
+    E   AssertionError: assert ((3.84375 - 1.71875) / 8.0) < 0.02
+"""
+
+TEST_FILE = '''\
+def test_req_7(monkeypatch):
+    calls = []
+    collector = WindowsCollector({})
+    collector.collect()
+    assert len(calls) == 1
+
+
+def test_req_8():
+    import time
+    collector = WindowsCollector({})
+    collector.collect()
+    start = time.process_time()
+    for _ in range(8):
+        collector.collect()
+    assert (time.process_time() - start) / 8.0 < 0.020
+'''
+
+WINDOWS_PY = '''\
+class WindowsCollector:
+    def collect(self):
+        return 0
+'''
+
+# The shape from the run: a test double with the same method name.
+BENCH_PY = '''\
+class DummyCollector:
+    def __init__(self, config=None):
+        self.config = config
+
+    def collect(self):
+        return 0
+
+    def _read_cmdline_safe(self, pid):
+        return []
+
+
+def test_bench_collect_is_cheap():
+    assert DummyCollector().collect() == 0
+'''
+
+# A double whose CLASS the failing test also names.
+USED_DOUBLE_PY = '''\
+class WindowsCollector:
+    """A stand-in with the production name; a test that constructs
+    WindowsCollector is exercising whichever file defines it."""
+
+    def collect(self):
+        return 0
+'''
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "tests" / "benchmark").mkdir(parents=True)
+    (tmp_path / "src" / "boostgauge" / "collectors").mkdir(parents=True)
+    (tmp_path / "tests" / "test_issue_4.py").write_text(TEST_FILE, encoding="utf-8")
+    (tmp_path / "tests" / "benchmark" / "test_windows_collector_bench.py").write_text(
+        BENCH_PY, encoding="utf-8"
+    )
+    (tmp_path / "src" / "boostgauge" / "collectors" / "windows.py").write_text(
+        WINDOWS_PY, encoding="utf-8"
+    )
+    (tmp_path / "tests" / "conftest_double.py").write_text(USED_DOUBLE_PY, encoding="utf-8")
+    return tmp_path
+
+
+class TestMethodNamesNeedTheirClass:
+    def test_a_double_sharing_only_a_method_name_is_not_attributed(self, repo):
+        assert not is_attributed(
+            CORPUS, "tests/benchmark/test_windows_collector_bench.py", repo
+        )
+
+    def test_the_file_defining_the_constructed_class_still_is(self, repo):
+        assert is_attributed(CORPUS, "src/boostgauge/collectors/windows.py", repo)
+
+    def test_a_file_whose_class_the_test_names_is_attributed_through_it(self, repo):
+        """Same method name, but this file's class is the one the test
+        constructs -- the method is evidence because its class is used."""
+        assert is_attributed(CORPUS, "tests/conftest_double.py", repo)
+
+
+class TestTopLevelFunctionsStillCount:
+    def test_a_top_level_function_the_test_calls_attributes(self, repo):
+        (repo / "src" / "boostgauge" / "helpers.py").write_text(
+            "def process_time():\n    return 0.0\n", encoding="utf-8"
+        )
+        # `process_time` is used as an attribute of `time` in the test; the
+        # helper defines it at top level. Attribute use of a top-level name
+        # still counts -- the rule tightened METHODS, not functions.
+        assert is_attributed(CORPUS, "src/boostgauge/helpers.py", repo)


### PR DESCRIPTION
## What happened

`run-issue4-151141` (boostgauge #4, 2026-09-05 15:11), green-loop iteration 3, the first iteration under #2861:

```
[N4] failures attributed to 4 of 6 file(s): src/boostgauge/collector.py, src/boostgauge/collectors/windows.py, tests/benchmark/test_windows_collector_bench.py, tests/unit/test_collector.py
```

The two source files are right: they define `WindowsCollector`, which the failing tests construct. The two test files are wrong, and their top-level definitions say why:

```
tests/benchmark/test_windows_collector_bench.py:21:class DummyCollector:
tests/benchmark/test_windows_collector_bench.py:27:    def collect(self):
tests/unit/test_collector.py:13:class DummyCollector(DataCollector):
tests/unit/test_collector.py:14:    def collect(self):
```

Each defines a test double with a `collect` method. The failing tests call `collector.collect()`, so `collect` is among the names they use, and #2861 counted a method of a top-level class as a defined name. Six files became four instead of two; the two extra cost a model call each (3–5 minutes apiece under the current prompt) and were files no failure was about.

## The change

`_names_defined_in` returns top-level names and methods separately, each method mapped to the classes that define it. A top-level class or function the test uses attributes the file that defines it, as before. A **method** name is evidence only when one of the classes that defines it is itself among the names the test uses. `collect` therefore attributes the files whose `WindowsCollector` defines it, and not a file whose `collect` hangs off `DummyCollector`.

The frame rule still runs first; the whole-corpus fallback still stands when nothing attributes; callers without a `repo_root` keep #2851's behaviour.

## Tests

`tests/unit/test_failure_attribution_method_names.py`, four cases on a real temporary tree shaped like the run (the two failing tests verbatim; a `DummyCollector` double with `collect`; the production `WindowsCollector`; a double that reuses the production class name):

- the double sharing only a method name is **not** attributed;
- the file defining the constructed class still is;
- a file whose class the test names is attributed through its method;
- a top-level function the test uses still attributes — the rule tightened methods, not functions.

`test_failure_attribution_by_test_body.py` and `test_failure_attribution_by_frame.py` pass unchanged.

Closes #2865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
