### PR TITLE
fix: the requirements-consistency gate judges the requirements, not the revision history (Closes #2870)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -66,6 +66,7 @@ report.
 from __future__ import annotations
 
 import json
+import re
 import time
 from typing import Any
 
@@ -470,6 +471,45 @@ def _halt_unverified(state: dict, answered_by: str, reason: str) -> dict[str, An
     return {"error_message": message, "requirements_unverified": reason}
 
 
+#: A heading that opens the issue's provenance section -- the dated log of
+#: rulings and the superseded text each one replaced. Any heading level,
+#: case-insensitive, matched on a whole line outside fenced code (#2870).
+_HISTORY_HEADING = re.compile(
+    r"^\s{0,3}#{1,6}\s*(revision history|revision log|changelog|change log|"
+    r"history|rulings|log of rulings)\b",
+    re.IGNORECASE,
+)
+
+
+def requirements_text(issue_body: str) -> tuple[str, int]:
+    """The body above its revision history, and how many lines were set aside.
+
+    #2870: boostgauge #4's launches 21 and 22 halted at this gate on
+    requirements that had passed it six times that day. The second halt's
+    reasoning said why -- "the historical recommendation mentioned in the
+    revision history." The history is a dated log of rulings; each entry
+    quotes the superseded sentence it replaced, because that is what a ruling
+    record does. Handed to the model as part of the requirements, every one
+    of those sentences reads as a live contradiction of the criterion that
+    replaced it, and the log grows by one entry per ruling. The gate was
+    being fed the record of its own past false positives.
+
+    A body with no history heading is returned whole with zero excluded. A
+    heading inside a fenced code block is text, not structure, and is not a
+    cut point.
+    """
+    lines = issue_body.splitlines()
+    in_fence = False
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and _HISTORY_HEADING.match(line):
+            kept = "\n".join(lines[:index]).rstrip()
+            return kept, len(lines) - index
+    return issue_body, 0
+
+
 def analyze_requirements(state: dict) -> dict[str, Any]:
     """N0c node body.
 
@@ -505,7 +545,16 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
             state, drafter_spec, f"invalid provider '{drafter_spec}': {e}"
         )
 
-    content = f"# Issue: {issue_title}\n\n{issue_body}"
+    # #2870: the gate judges the requirements. The revision history below
+    # them is provenance -- superseded text, quoted on purpose -- and is not
+    # handed to the model as something to find contradictions in.
+    judged, excluded = requirements_text(issue_body)
+    if excluded:
+        print(
+            f"  [N0c] judging {len(judged.splitlines())} lines of requirements; "
+            f"revision history ({excluded} lines) excluded as provenance (#2870)"
+        )
+    content = f"# Issue: {issue_title}\n\n{judged}"
 
     def _invoke(active_provider):
         schema_kwargs: dict[str, Any] = {}

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 9016,
+    "sites_examined": 9021,
     "findings_total": 540
   },
   "undeclared": [

--- a/tests/unit/test_n0c_excludes_revision_history.py
+++ b/tests/unit/test_n0c_excludes_revision_history.py
@@ -1,0 +1,136 @@
+"""N0c judges the requirements, not the revision history (#2870).
+
+boostgauge #4, 2026-09-05: launches 21 and 22 halted at the
+requirements-consistency gate on text that had passed it on launches 14,
+15, 17, 18, 19 and 20. The second halt's reasoning named the cause: "the
+historical recommendation mentioned in the revision history."
+
+The revision history is a dated log of rulings; each entry quotes the
+superseded sentence it replaced. Handed to the model as requirements, every
+one of those sentences reads as a live contradiction of the criterion that
+replaced it, and the log grows by one entry per ruling.
+
+The first class tests the cut itself. The second drives `analyze_requirements`
+with the provider stubbed at its boundary and asserts what the model was
+actually shown.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# The package re-exports the node FUNCTION under the module's name, so a
+# `from ... import analyze_requirements` yields the function. Import the
+# module itself.
+n0c = importlib.import_module(
+    "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+)
+
+LIVE = """\
+# Collector
+
+## Acceptance criteria
+
+- [ ] < 2% CPU overhead at 2s polling interval: mean process_time over 8 ticks is < 40 ms
+- [ ] All process-derived metrics come from a single sweep of the process table per tick
+"""
+
+HISTORY = """\
+## Revision history
+
+**2026-09-01** — a hand spike measured the sweep at 422 ms against the `< 1%` criterion (20 ms) and recommended `len(psutil.pids())` for process count.
+
+**2026-09-05** — ruling: the CPU criterion is now `< 2%`, 40 ms.
+"""
+
+BODY = LIVE + "\n" + HISTORY
+
+
+class TestTheCut:
+    def test_cuts_at_the_revision_history_heading(self):
+        kept, excluded = n0c.requirements_text(BODY)
+
+        assert "< 40 ms" in kept
+        assert "Revision history" not in kept
+        assert "psutil.pids()" not in kept, "the superseded recommendation must not reach the model"
+        assert excluded == len(HISTORY.splitlines())
+
+    @pytest.mark.parametrize(
+        "heading",
+        ["## Revision history", "### REVISION HISTORY", "# Changelog", "## History", "## Rulings", "## Change log"],
+    )
+    def test_recognises_the_family_of_headings_at_any_level(self, heading):
+        kept, excluded = n0c.requirements_text(LIVE + "\n" + heading + "\n\nold text\n")
+
+        assert "old text" not in kept
+        assert excluded == 3
+
+    def test_a_body_without_a_history_is_returned_whole(self):
+        kept, excluded = n0c.requirements_text(LIVE)
+
+        assert kept == LIVE
+        assert excluded == 0
+
+    def test_a_heading_inside_a_code_fence_is_text_not_structure(self):
+        body = LIVE + "\n```markdown\n## Revision history\nexample entry\n```\n\n- [ ] one more criterion\n"
+
+        kept, excluded = n0c.requirements_text(body)
+
+        assert "one more criterion" in kept
+        assert excluded == 0
+
+    def test_a_word_in_prose_is_not_a_heading(self):
+        body = LIVE + "\nThe history of this metric is long.\n- [ ] last criterion\n"
+
+        kept, excluded = n0c.requirements_text(body)
+
+        assert "last criterion" in kept
+        assert excluded == 0
+
+
+class TestWhatTheModelIsShown:
+    def _run(self, body: str, capsys):
+        shown: list[str] = []
+
+        class _Provider:
+            def invoke(self, system_prompt, content, timeout_seconds, **kwargs):
+                shown.append(content)
+                return SimpleNamespace(
+                    success=True,
+                    response='{"is_consistent": true, "conflicts": [], "notes": []}',
+                    error_message="",
+                )
+
+        state = {
+            "issue_title": "Collector",
+            "issue_body": body,
+            "config_drafter": "gemini:3.1-pro",
+        }
+        with patch("assemblyzero.core.llm_provider.get_provider", return_value=_Provider()):
+            result = n0c.analyze_requirements(state)
+        return result, shown, capsys.readouterr().out
+
+    def test_the_model_sees_only_the_live_requirements(self, capsys):
+        result, shown, out = self._run(BODY, capsys)
+
+        assert result == {}, result
+        assert len(shown) == 1
+        assert "< 40 ms" in shown[0]
+        assert "psutil.pids()" not in shown[0]
+        assert "Revision history" not in shown[0]
+
+    def test_the_exclusion_is_named_in_the_log(self, capsys):
+        _, _, out = self._run(BODY, capsys)
+
+        assert "excluded as provenance (#2870)" in out
+        assert f"revision history ({len(HISTORY.splitlines())} lines)" in out
+
+    def test_a_body_without_a_history_prints_no_exclusion(self, capsys):
+        _, shown, out = self._run(LIVE, capsys)
+
+        assert LIVE.strip() in shown[0]
+        assert "excluded as provenance" not in out


### PR DESCRIPTION
## What happened

boostgauge #4, 2026-09-05. Launches 21 and 22 both halted at the requirements-consistency gate (N0c), after 286 s and 271 s, each filing a must-resolve issue. Between launch 20 (which passed this gate) and launch 21 the requirements changed by one number — the CPU criterion, 20 ms → 40 ms, by operator ruling. Between launches 21 and 22 they changed by one clarifying sentence.

**#436 (launch 21):** the gate read `normalize(value, threshold)` as a function of a single number. The same algorithm section, byte-identical, had passed this gate on launches 14, 15, 17, 18, 19 and 20.

**#437 (launch 22):** the gate found the single-sweep section against the single-sweep criterion, and gave its reasoning:

> Following the first reading (and the historical recommendation mentioned in the revision history), an implementation might use a separate walk (e.g., `len(psutil.pids())`) for Process count.

The revision history is where that "recommendation" lives. It is a dated log of the rulings made on the issue; each entry quotes the superseded text it replaced, because that is what a ruling record does. N0c hands the model the whole body:

```python
content = f"# Issue: {issue_title}\n\n{issue_body}"
```

So every superseded sentence in the history reads as a live contradiction of the criterion that replaced it — and the log grows by one entry per ruling. The gate was being fed the record of its own past false positives and finding new ones in it. Both halts were resolved by wording rulings that changed no behaviour; each cost a halt, a filed issue, a ruling, a close and a relaunch.

## The change

`requirements_text(issue_body)` returns everything above the first heading that names a revision history, changelog or log of rulings (`## Revision history`, `## Changelog`, `## History`, `## Rulings` — any heading level, case-insensitive), and the number of lines it set aside. N0c judges that text and prints `[N0c] judging N lines of requirements; revision history (M lines) excluded as provenance` when anything was excluded. A body with no such heading is judged whole, exactly as before.

The LLD drafter (`generate_draft.py`) and the input loader (`load_input.py`) hand the model the whole body too. They are left alone here: a drafter that can see the rulings is arguably better informed, and the two halts were the gate's. If a drafter is ever found drafting against a superseded sentence, the same helper applies.

## Tests

`tests/unit/test_n0c_excludes_revision_history.py`:

- `requirements_text` cuts at `## Revision history` and reports the excluded line count; the live criterion survives, the superseded one quoted in the history does not;
- the cut is case-insensitive and heading-level-agnostic, and recognises `Changelog`, `History` and `Rulings`;
- a body with no history heading is returned whole with zero excluded;
- a heading inside a fenced code block is not a cut point;
- driven through `analyze_requirements` with the provider stubbed: the model receives only the live text, and the log names the exclusion.

Closes #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
