### PR TITLE
fix: a template-read verdict stores its Tier 1/2 issues as the feedback, so the two-strike compares issues and the drafter sees them; the halt counts reviews (Closes #2872, Closes #2873)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -152,7 +152,15 @@ def describe_halt_from_state(state: dict, workflow_name: str) -> str:
     the blank it replaces. Every branch names the field it read.
     """
     verdict = state.get("review_verdict") or state.get("lld_status") or ""
-    iteration = state.get("review_iteration") or state.get("iteration_count") or 0
+    # #2873: the requirements workflow counts reviews in `verdict_count`
+    # (#1509 -- iteration_count is bumped by every state-touching node, six
+    # of them per review on run-issue4-184136). Read it before falling back.
+    iteration = (
+        state.get("review_iteration")
+        or state.get("verdict_count")
+        or state.get("iteration_count")
+        or 0
+    )
     cap = state.get("max_iterations", 0)
 
     if verdict and cap and iteration >= cap:

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -623,12 +623,26 @@ def _extract_actionable_feedback(
     Returns:
         Concise actionable feedback string.
     """
-    # Issue #775: Prefer structured feedback_items when available
-    if feedback_result and feedback_result["source"] == "structured":
+    # Issue #775: Prefer structured feedback_items when available.
+    #
+    # #2872: the 0702c template path (#2835, source "markdown_template") is
+    # the same case -- its feedback_items ARE the Tier 1 and Tier 2 bullets.
+    # Left out of this branch, the template path fell through to the bare
+    # `Verdict: BLOCKED` below (response is "" there, and `structured` is a
+    # shell with no items), so the drafter's revision prompt carried no
+    # issues and the two-strike rule compared two identical one-liners and
+    # halted a loop that had just gone from three blocking issues to one.
+    if feedback_result and feedback_result["source"] in ("structured", "markdown_template"):
         items = feedback_result["feedback_items"]
         if items:
             return "\n".join(f"- {item}" for item in items)
-        return ""
+        if feedback_result["source"] == "structured":
+            return ""
+        # A template with no Tier bullets still has a Review Summary and
+        # Tier sections worth more than the bare status: read them below
+        # from the whole text, which the template reader keeps as rationale.
+        verdict_content = verdict_content or feedback_result.get("rationale", "")
+        structured = None
 
     if not verdict_content or not verdict_content.strip():
         return f"Verdict: {lld_status}"

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 9021,
+    "sites_examined": 9022,
     "findings_total": 540
   },
   "undeclared": [

--- a/tests/unit/test_template_verdicts_are_not_stagnant.py
+++ b/tests/unit/test_template_verdicts_are_not_stagnant.py
@@ -1,0 +1,173 @@
+"""Two different template verdicts are not "the same issues" (#2872), and the
+halt counts reviews, not node visits (#2873).
+
+boostgauge #4, `run-issue4-184136` (2026-09-05), design stage. Review 1 raised
+three Tier 1 issues (loop bounds on the NextEntryOffset walk; segfault
+prevention in the ctypes parse; NULL ImageName on PIDs 0 and 4). The drafter
+fixed all three. Review 2 raised one new Tier 1 issue (a bounded queue blocks
+on put()). The stage halted: "Two consecutive BLOCKED verdicts with same
+issues." The halt message said "Halted after 6 round(s) ... no recorded
+reason."
+
+Both reviews were read from the 0702c template (#2835). On that path
+`response` is "" and `structured` is a shell with no items, so
+`_extract_actionable_feedback` -- which never learned the template source --
+returned the bare `Verdict: BLOCKED` for both. The two-strike compared two
+identical one-liners. The fixtures below are the two verdicts reduced to
+what the template reader reads: the Verdict box and the Tier sections, with
+the real issue titles.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from assemblyzero.core.halt_node import describe_halt_from_state
+from assemblyzero.core.verdict_schema import parse_markdown_feedback, same_blocking_issues
+
+review = importlib.import_module("assemblyzero.workflows.requirements.nodes.review")
+
+
+def _template(tier1: list[str], tier2: list[str], summary: str) -> str:
+    t1 = "\n".join(f"- [ ] **{t}:** detail." for t in tier1) or "- [ ] No issues found."
+    t2 = "\n".join(f"- [ ] **{t}:** detail." for t in tier2) or "- [ ] No issues found."
+    return f"""# LLD Review: #4-Windows data collector
+
+## Identity Confirmation
+I am Gemini 3 Pro, acting as Senior Software Architect & AI Governance Lead.
+
+## Pre-Flight Gate
+PASSED
+
+## Review Summary
+{summary}
+
+## Open Questions Resolved
+None.
+
+## Tier 1: BLOCKING Issues
+
+### Cost
+- [ ] No issues found.
+
+### Safety
+{t1}
+
+### Security
+- [ ] No issues found.
+
+### Legal
+- [ ] No issues found.
+
+## Tier 2: HIGH PRIORITY Issues
+
+### Architecture
+{t2}
+
+### Observability
+- [ ] No issues found.
+
+### Quality
+- [ ] No issues found.
+
+## Tier 3: SUGGESTIONS
+- Consider a default maxsize on the queue.
+
+## Questions for Orchestrator
+None.
+
+## Verdict
+[ ] **APPROVED** - Ready for implementation
+[x] **REVISE** - Fix Tier 1/2 issues first
+[ ] **DISCUSS** - Needs Orchestrator decision
+"""
+
+
+REVIEW_1 = _template(
+    tier1=[
+        "Loop bounds undefined for memory parsing",
+        "Fail-Safe Strategy (Segfault Prevention)",
+        "Fail-Safe Strategy (System Process Names)",
+    ],
+    tier2=[],
+    summary="Solid approach; three memory-safety gaps in the sweep.",
+)
+
+REVIEW_2 = _template(
+    tier1=["Fail-Safe Strategy (Queue Blocking)"],
+    tier2=[
+        "Interface Correctness (`composite` missing argument)",
+        "Interface Correctness (Data Structure Fields)",
+    ],
+    summary="Memory safety addressed; one thread-blocking risk and two signature slips.",
+)
+
+
+def _stored_feedback(raw: str) -> str:
+    """Exactly what review.py stores in `current_verdict` on the template path."""
+    fr = parse_markdown_feedback(raw)
+    assert fr is not None and fr["source"] == "markdown_template"
+    structured = {"verdict": fr["verdict"], "rationale": fr["rationale"]}
+    return review._extract_actionable_feedback("", "BLOCKED", structured, feedback_result=fr)
+
+
+class TestTheStoredFeedbackCarriesTheIssues:
+    def test_review_one_stores_its_three_blocking_issues(self):
+        stored = _stored_feedback(REVIEW_1)
+
+        assert stored != "Verdict: BLOCKED"
+        assert "Loop bounds undefined" in stored
+        assert "Segfault Prevention" in stored
+        assert "System Process Names" in stored
+
+    def test_review_two_stores_its_one_blocking_issue_and_its_tier_two(self):
+        stored = _stored_feedback(REVIEW_2)
+
+        assert "Queue Blocking" in stored
+        assert "composite" in stored
+
+    def test_a_template_with_no_items_still_stores_more_than_the_status(self):
+        raw = _template(tier1=[], tier2=[], summary="Nothing blocking; see suggestions.")
+
+        stored = _stored_feedback(raw)
+
+        assert stored != "Verdict: BLOCKED"
+        assert "Nothing blocking" in stored or "SUGGESTIONS" in stored
+
+
+class TestTheTwoStrikeReadsIssuesNotStatus:
+    def test_run_24s_two_reviews_are_not_the_same_issues(self):
+        first = _stored_feedback(REVIEW_1)
+        second = _stored_feedback(REVIEW_2)
+
+        assert not same_blocking_issues(second, first)
+
+    def test_a_genuinely_repeated_review_is_still_stagnation(self):
+        first = _stored_feedback(REVIEW_1)
+        again = _stored_feedback(REVIEW_1)
+
+        assert same_blocking_issues(again, first)
+
+    def test_the_bare_status_was_the_defect(self):
+        """The shape the code produced before #2872: identical by construction."""
+        assert same_blocking_issues("Verdict: BLOCKED", "Verdict: BLOCKED")
+
+
+class TestTheHaltCountsReviews:
+    def test_round_count_reads_verdict_count_before_iteration_count(self):
+        state = {
+            "lld_status": "BLOCKED",
+            "verdict_count": 2,
+            "iteration_count": 6,
+            "max_iterations": 3,
+        }
+
+        message = describe_halt_from_state(state, "requirements")
+
+        assert "2 round(s)" in message, message
+        assert "6 round(s)" not in message
+
+    def test_workflows_without_verdict_count_are_unchanged(self):
+        state = {"lld_status": "BLOCKED", "iteration_count": 4, "max_iterations": 9}
+
+        assert "4 round(s)" in describe_halt_from_state(state, "testing")


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-184136` (2026-09-05 18:41), design stage:

```
[N3] Reviewing draft (review #1)...
    [N3] verdict read from the 0702c review template, not JSON (#2835): REVISE
    [VERDICT] REVISE with 3 Tier 1 BLOCKING issue(s) — BLOCKED.
    Verdict: BLOCKED (1 lines in feedback)
[N1] Generating revision (draft #2)...
    [EDIT-SCRIPT] Applied 5 edit(s); 89% of prior draft preserved byte-identical (#2200)
[N3] Reviewing draft (review #2)...
    [VERDICT] REVISE with 1 Tier 1 BLOCKING issue(s) — BLOCKED.
    Verdict: BLOCKED (1 lines in feedback)
    [HALT] Two consecutive BLOCKED verdicts with same issues. Halting.
  Error: Halted after 6 round(s) with verdict BLOCKED and no recorded reason; see the state snapshot for the full transcript.
```

Review 1 (`003-verdict.md`): loop bounds on the `NextEntryOffset` walk; segfault prevention in the `ctypes` parse; NULL `ImageName` on PIDs 0 and 4. Review 2 (`005-verdict.md`): a bounded `queue.Queue` blocks on `put()`. Three fixed, one new. A converging loop, halted as stagnant.

## Why — #2872

`_extract_actionable_feedback` (#506) decides what goes into `current_verdict`: the drafter's revision feedback and the text the two-strike rule compares. It knew two shapes — structured JSON (`source == "structured"` → the `feedback_items`) and raw markdown (regex over the Tier sections of `verdict_content`). #2835 added a third: the reviewer's answer read from the 0702c template, `source == "markdown_template"`. This function never learned it. On that path `response` is `""` (`review.py:265`) and `structured` is `{"verdict", "rationale"}` with no items (`:271`), so Path 1 finds nothing and returns `f"Verdict: {lld_status}"`. Both reviews stored the single line `Verdict: BLOCKED`. `same_blocking_issues` on two identical one-liners is True by the line-overlap fallback.

**Change.** The template source is handled like the structured one: the Tier 1 and Tier 2 `feedback_items` are the stored feedback, one bullet per line. A template with no bullets falls through to the Tier/Summary extraction over the whole text (which the template reader keeps as `rationale`) rather than the bare status, so two different empty-item verdicts cannot compare equal by construction.

## Why — #2873

The halt message read `review_iteration or iteration_count`. The requirements workflow's per-review counter is `verdict_count` (#1509 moved the cap onto it precisely because `iteration_count` is bumped by every state-touching node — six per review here). It now reads `verdict_count` before falling back, so "N round(s)" is the number of reviews. "No recorded reason" was the other face of #2872: with the issues in `current_verdict`, the halt has a reason to print.

## Tests

`tests/unit/test_template_verdicts_are_not_stagnant.py`, eight cases, on run 24's two reviews reduced to what the template reader reads (the Verdict box and the Tier sections, with the real issue titles), driven through the real `parse_markdown_feedback` → `_extract_actionable_feedback` → `same_blocking_issues` chain exactly as `review.py` calls it (`response=""`, the shell `structured`):

- review 1 stores its three blocking issues; review 2 stores its one plus its Tier 2; a template with no bullets stores more than the status;
- run 24's two reviews are **not** the same issues; a genuinely repeated review still is; `same_blocking_issues("Verdict: BLOCKED", "Verdict: BLOCKED")` is True — the defect's shape, pinned;
- the halt message says "2 round(s)" with `verdict_count=2, iteration_count=6`; a workflow without `verdict_count` is unchanged.

`test_structured_stagnation.py` and `test_review_convergence.py` pass unchanged.

Closes #2872
Closes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)
