### PR TITLE
fix: a chain rooted in a name the spec never binds, that the target env can import, is a dependency's API and not judged against the repo's symbols (Closes #2876)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -27,7 +27,7 @@ import sys
 import textwrap
 import tomllib
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 from assemblyzero.workflows.implementation_spec.state import (
     CompletenessCheck,
@@ -3319,6 +3319,7 @@ def _flag_calls(
     facts: list[_FenceFacts],
     symbol_set: set[str],
     first_party_tops: frozenset[str] = frozenset(),
+    importable: Callable[[list[str]], set[str]] | None = None,
 ) -> dict[str, list[str]]:
     """Judge every collected call against the target repo's symbol table.
 
@@ -3383,6 +3384,39 @@ def _flag_calls(
     foreign_roots: set[str] = set(framework_roots)
     foreign_roots |= imported_roots - first_party_tops
     foreign_roots |= set(_STDLIB_MODULE_NAMES) - first_party_tops
+
+    # #2876: a chain rooted in a name NOTHING in the spec binds -- not an
+    # import, a definition, an assignment, a parameter, a class -- that the
+    # target repo does not own and that is not a gathered symbol. A spec's
+    # excerpts routinely omit their import header, so `psutil.Process(pid)`
+    # and `pytest.mark.skipif(...)` arrived with roots the checker had never
+    # seen bound and fell through to the symbol test as though the repo owned
+    # them (run-issue4-190442: two of three spec rounds spent dodging correct
+    # calls; run-issue4-193821 opened the same way with `pytest.raises`).
+    #
+    # The discriminator is the target environment, the authority #1904 uses
+    # for third-party imports: an unbound root that IMPORTS there is a module
+    # the excerpt elided the import of, and is foreign. One that does not --
+    # `win` in `def f(win): win.model_dump()` -- stays judged, so #1527's
+    # founding true positive is untouched. Asked once, batched, and only about
+    # roots nothing binds; a probe that cannot answer adds no exemption.
+    if importable is not None:
+        bound: set[str] = set(imported_roots) | spec_defined | framework_roots
+        for fence in facts:
+            bound |= fence.classes | fence.opaque
+            bound |= {name for name, _root in fence.annotated}
+            for bound_names, _source in fence.assignments:
+                bound |= bound_names
+        candidates = sorted({
+            call.root for fence in facts for call in fence.calls
+            if call.root is not None
+            and call.root not in bound
+            and call.root not in foreign_roots
+            and call.root not in first_party_tops
+            and call.root not in symbol_set
+        })
+        if candidates:
+            foreign_roots |= set(importable(candidates)) - first_party_tops
 
     # Exemption propagates through bindings to a fixed point rather than the
     # single level the old regex managed: `self.root = tk.Tk()` exempts `root`,
@@ -3568,6 +3602,7 @@ def detect_unknown_method_calls(
     text: str,
     symbol_set: set[str],
     repo_root_str: str = "",
+    importable: Callable[[list[str]], set[str]] | None = None,
 ) -> dict[str, list[str]]:
     """Scan code fences in ``text`` for method calls absent from ``symbol_set``.
 
@@ -3589,8 +3624,30 @@ def detect_unknown_method_calls(
         Empty when every call resolves to a known or allowlisted symbol.
     """
     return _flag_calls(
-        _scan_fences(text).facts, symbol_set, _first_party_tops_for(repo_root_str)
+        _scan_fences(text).facts, symbol_set, _first_party_tops_for(repo_root_str),
+        importable=importable if importable is not None else _importable_probe_for(repo_root_str),
     )
+
+
+def _importable_probe_for(repo_root_str: str):
+    """A batched "which of these names import in the target env" probe (#2876).
+
+    Returns a callable ``roots -> set of importable roots``, or None when
+    there is no repo root to probe. The probe is `_probe_target_env`, the
+    same authority #1904 uses for third-party imports; when IT cannot answer
+    (no venv, timeout) the callable returns an empty set, which adds no
+    exemption -- the check behaves exactly as before rather than guessing.
+    """
+    if not repo_root_str:
+        return None
+
+    def _probe(roots: list[str]) -> set[str]:
+        answer = _probe_target_env(Path(repo_root_str), sorted(roots))
+        if not answer:
+            return set()
+        return {name for name, ok in answer.items() if ok}
+
+    return _probe
 
 
 def _first_party_tops_for(repo_root_str: str) -> frozenset[str]:
@@ -3700,7 +3757,8 @@ def check_api_symbols_exist(
         )
 
     flagged = _flag_calls(
-        scan.facts, symbol_set, _first_party_tops_for(repo_root_str)
+        scan.facts, symbol_set, _first_party_tops_for(repo_root_str),
+        importable=_importable_probe_for(repo_root_str),
     )
 
     # #1870's honesty rule applied to the scan itself: say what was NOT read,
@@ -3768,6 +3826,8 @@ _API_SYMBOL_ALLOWLIST: frozenset[str] = frozenset({
     "copy", "clear", "fromkeys",
     # ---- built-in type methods — list ----
     "append", "extend", "insert", "remove", "reverse", "sort", "count",
+    # ---- threading.Thread (#2876: `t.is_alive()` on run-issue4-190442) ----
+    "is_alive",
     # ---- built-in type methods — str ----
     "strip", "lstrip", "rstrip", "split", "rsplit", "splitlines",
     "join", "replace", "startswith", "endswith", "upper", "lower",

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 9022,
+    "sites_examined": 9030,
     "findings_total": 540
   },
   "undeclared": [

--- a/tests/unit/test_unbound_module_roots_are_foreign.py
+++ b/tests/unit/test_unbound_module_roots_are_foreign.py
@@ -1,0 +1,146 @@
+"""A chain rooted in a name the spec never binds, that the target env can
+import, is a dependency's API and not the target repo's (#2876).
+
+boostgauge #4, `run-issue4-190442` and `run-issue4-193821`, spec stage:
+
+    Spec calls methods not found in the target project's gathered symbols:
+    `AccessDenied` (e.g. `raise psutil.AccessDenied()`); `Process` (e.g.
+    `p = psutil.Process(pid)`); `pids` (e.g. `for pid in psutil.pids():`);
+    `skipif` (e.g. `pytestmark = pytest.mark.skipif(...)`); `is_alive`
+    (e.g. `assert not t.is_alive()`) ...
+
+`_flag_calls` exempts a chain rooted in an imported name (#1948, #2411) --
+but only when some fence shows the import, and a spec's excerpts routinely
+omit their import header. `psutil` and `pytest` were roots the checker had
+never seen bound, and an unbound root fell through to the symbol test as
+though the target repo owned it. Two of three spec rounds went to dodging
+correct calls.
+
+The discriminator is the target environment, the same authority #1904 uses
+for third-party imports: an unbound root that IMPORTS there is a module the
+spec elided the import of; one that does not (a bare parameter such as
+`win` in `def f(win): win.model_dump()`) stays judged, so #1527's founding
+true positive is untouched. The probe is injected here; the real one is
+`_probe_target_env` against the target venv.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    detect_unknown_method_calls,
+)
+
+TARGET_SYMBOLS = {"WindowsCollector", "DataCollector", "collect"}
+
+# Excerpts as the drafter writes them: usage without the import header.
+RUN_25_SHAPE = """# Spec
+
+```python
+def _read_cmdline_safe(self, pid: int) -> list[str]:
+    try:
+        return psutil.Process(pid).cmdline()
+    except psutil.AccessDenied:
+        return []
+
+
+def _all_pids():
+    for pid in psutil.pids():
+        yield pid
+```
+
+```python
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows sweep")
+
+
+def test_thread_stops():
+    t = threading.Thread(target=lambda: None)
+    t.start()
+    t.join()
+    assert not t.is_alive()
+```
+"""
+
+FOUNDING_TRUE_POSITIVE = """# S
+
+```python
+def f(win):
+    win.model_dump()
+```
+"""
+
+
+def _env_with(*modules: str):
+    known = set(modules)
+
+    def probe(roots: list[str]) -> set[str]:
+        return {r for r in roots if r in known}
+
+    return probe
+
+
+class TestUnboundModuleRootsAreForeign:
+    def test_psutil_and_pytest_chains_pass_without_an_import_line(self):
+        flagged = detect_unknown_method_calls(
+            RUN_25_SHAPE, TARGET_SYMBOLS, "", importable=_env_with("psutil", "pytest")
+        )
+
+        for name in ("Process", "AccessDenied", "pids", "skipif", "cmdline"):
+            assert name not in flagged, f"{name} flagged: {flagged.get(name)}"
+
+    def test_a_bare_parameter_is_not_a_module_and_stays_judged(self):
+        flagged = detect_unknown_method_calls(
+            FOUNDING_TRUE_POSITIVE, TARGET_SYMBOLS, "", importable=_env_with("psutil", "pytest")
+        )
+
+        assert "model_dump" in flagged
+
+    def test_a_root_the_env_cannot_import_stays_judged(self):
+        """`psutil` absent from the env: the checker has no grounds to exempt it."""
+        flagged = detect_unknown_method_calls(
+            RUN_25_SHAPE, TARGET_SYMBOLS, "", importable=_env_with("pytest")
+        )
+
+        assert "Process" in flagged
+        assert "skipif" not in flagged
+
+    def test_no_probe_keeps_the_previous_behaviour(self):
+        flagged = detect_unknown_method_calls(RUN_25_SHAPE, TARGET_SYMBOLS, "")
+
+        assert "Process" in flagged
+
+    def test_a_probe_that_cannot_answer_adds_no_exemption(self):
+        flagged = detect_unknown_method_calls(
+            RUN_25_SHAPE, TARGET_SYMBOLS, "", importable=lambda roots: set()
+        )
+
+        assert "Process" in flagged
+
+
+class TestIsAliveIsAThreadMethod:
+    def test_is_alive_is_not_a_project_api(self):
+        flagged = detect_unknown_method_calls(RUN_25_SHAPE, TARGET_SYMBOLS, "")
+
+        assert "is_alive" not in flagged
+
+
+class TestTheProbeIsAskedOnlyAboutUnboundRoots:
+    def test_bound_and_first_party_roots_are_not_probed(self):
+        asked: list[list[str]] = []
+
+        def recording(roots: list[str]) -> set[str]:
+            asked.append(sorted(roots))
+            return set()
+
+        spec = """# S
+
+```python
+import json
+collector = WindowsCollector({})
+collector.collect()
+json.dumps({})
+psutil.pids()
+```
+"""
+        detect_unknown_method_calls(spec, TARGET_SYMBOLS, "", importable=recording)
+
+        assert asked == [["psutil"]], asked


### PR DESCRIPTION
## What happened

boostgauge #4, spec stage, `run-issue4-190442` (19:04) and `run-issue4-193821` (19:38):

```
Spec calls methods not found in the target project's gathered symbols: `AccessDenied` (e.g. `raise psutil.AccessDenied()`); `fail` (e.g. `pytest.fail(...)`); `is_alive` (e.g. `assert not t.is_alive()`); …
Spec calls methods not found in the target project's gathered symbols: `Process` (e.g. `p = psutil.Process(pid)`); `pids` (e.g. `for pid in psutil.pids():`); `skipif` (e.g. `pytestmark = pytest.mark.skipif(...)`) …
Spec calls methods not found in the target project's gathered symbols: `raises` (e.g. `with pytest.raises(OSError):`) …
```

Every one is a dependency's documented API. In run 25, rounds 1 and 2 of three went to rewriting them; round 3 was the only one left for the check that mattered (#2875). Run 26 opened with `pytest.raises` flagged — the very form the error-path check demands — and the drafter removed it to satisfy the symbol gate, at which point the error-path check fired again. A knot of two checks.

## Why

`_flag_calls` exempts a chain rooted in an imported name (#1948, #2411) and in a stdlib module name — when some fence shows the import. A spec's excerpts routinely omit their import header (the module says so at the fence scanner). `psutil` and `pytest` were roots the checker had never seen bound, and an unbound root fell through to the symbol test as though the target repo owned it.

## The change

An unbound root — nothing in the spec imports, defines, assigns, annotates or declares it; the repo does not own it; it is not a gathered symbol — is put to the **target environment**: `_probe_target_env`, the authority #1904 already uses for third-party imports. A root that imports there is a module the excerpt elided, and is foreign. One that does not — `win` in `def f(win): win.model_dump()` — stays judged, so #1527's founding true positive is untouched. The probe is asked once per check, batched, only about unbound roots; when it cannot answer (no venv, timeout) it returns nothing and no exemption is added — the check behaves exactly as before rather than guessing. The telemetry consumer (`detect_unknown_method_calls` without a repo root) gets no probe and is unchanged.

`is_alive` joins the hand-curated stdlib allowlist as `threading.Thread`'s.

## Tests

`tests/unit/test_unbound_module_roots_are_foreign.py`, seven cases, the probe injected:

- run 25's shape (usage without import headers): `Process`, `AccessDenied`, `pids`, `skipif`, `cmdline` not flagged when the env imports `psutil` and `pytest`;
- the founding true positive: `win.model_dump()` still flagged under the same env;
- `psutil` absent from the env: `Process` still flagged, `skipif` not;
- no probe, and a probe that cannot answer: today's behaviour, `Process` flagged;
- `t.is_alive()` not flagged;
- the probe is asked only about unbound roots — a bound `collector`, a first-party `WindowsCollector` and an imported `json` are never sent to it; `psutil` is.

The six existing symbol-gate suites pass unchanged.

Closes #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
