### PR TITLE
fix: a plan's Modify for a file the base does not have is implemented as an Add, not refused (Closes #2879)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -361,7 +361,18 @@ def validate_files_to_modify(
     paths immediately so we don't waste tokens on invalid paths.
 
     Rules:
-    - Modify/Delete: file must exist on disk (hard fail)
+    - Modify whose target is absent: implemented as an Add (#2879). The
+      plan's change type is its guess about the base, and the truth is on
+      disk -- the operator's #2736 ruling that the LLD's file list is a plan,
+      not a contract, applied to the type as well as the path. This is the
+      inverse of `resolve_change_type` (#2032/#2033), which turns an Add whose
+      file the base ships into a Modify. On run-issue4-193821 the design
+      called all five of #4's deliverables Modify against a from-seed base
+      that had none of them, and this guard ended a run that had just cleared
+      the gate, the design and the spec, in five seconds. The spec dict is
+      coerced in place so the loop implements it as an Add, and the coercion
+      is printed.
+    - Delete: file must exist on disk (hard fail)
     - Add: auto-create parent directory if missing (Issue #468)
 
     Args:
@@ -378,7 +389,16 @@ def validate_files_to_modify(
         change_type = file_spec.get("change_type", "Add")
         full_path = repo_root / file_path
 
-        if change_type.lower() in ("modify", "delete"):
+        if change_type.lower() == "modify" and not full_path.exists():
+            print(
+                f"    [PLAN] says Modify but the base has no {file_path}; "
+                f"implementing as Add (#2736: the file list is a plan, not a "
+                f"contract)"
+            )
+            file_spec["change_type"] = "Add"
+            change_type = "Add"
+
+        if change_type.lower() == "delete":
             if not full_path.exists():
                 errors.append(
                     f"{change_type} target does not exist: {file_path}"

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 303,
-    "sites_examined": 9030,
+    "sites_examined": 9031,
     "findings_total": 540
   },
   "undeclared": [

--- a/tests/unit/test_implement_code_path_validation.py
+++ b/tests/unit/test_implement_code_path_validation.py
@@ -6,7 +6,6 @@ Add behavior to auto-create parent directories instead of erroring.
 """
 
 import pytest
-from pathlib import Path
 
 from assemblyzero.workflows.testing.nodes.implement_code import (
     validate_files_to_modify,
@@ -35,15 +34,23 @@ def test_all_paths_valid_returns_empty(tmp_repo):
     assert errors == []
 
 
-def test_modify_file_missing_returns_error(tmp_repo):
-    """Wrong path for Modify -> error."""
+def test_modify_file_missing_is_implemented_as_an_add(tmp_repo, capsys):
+    """#2879: a Modify whose target is absent is an Add, not an error.
+
+    This case asserted the refusal from #445 until run-issue4-193821, when
+    the refusal ended a run that had cleared the gate, the design and the
+    spec, five seconds into the implementation stage. The operator's #2736
+    ruling -- the file list is a plan, not a contract -- governs the change
+    type as it governs the path.
+    """
     files = [
         {"path": "src/workflows/tdd/runner.py", "change_type": "Modify"},
     ]
     errors = validate_files_to_modify(files, tmp_repo)
-    assert len(errors) == 1
-    assert "Modify target does not exist" in errors[0]
-    assert "src/workflows/tdd/runner.py" in errors[0]
+    assert errors == []
+    assert files[0]["change_type"] == "Add"
+    assert (tmp_repo / "src" / "workflows" / "tdd").is_dir()
+    assert "says Modify but the base has no src/workflows/tdd/runner.py" in capsys.readouterr().out
 
 
 def test_delete_file_missing_returns_error(tmp_repo):
@@ -83,8 +90,12 @@ def test_multiple_errors_collected(tmp_repo):
         {"path": "src/no_parent/file3.py", "change_type": "Add"},
     ]
     errors = validate_files_to_modify(files, tmp_repo)
-    # Modify + Delete both error; Add auto-creates parent (Issue #468)
-    assert len(errors) == 2
+    # Delete errors; the Modify is coerced to an Add (#2879); both Adds
+    # auto-create their parents (Issue #468).
+    assert len(errors) == 1
+    assert "Delete target does not exist" in errors[0]
+    assert files[0]["change_type"] == "Add"
+    assert (tmp_repo / "src" / "bad_path").is_dir()
     assert (tmp_repo / "src" / "no_parent").is_dir()
 
 

--- a/tests/unit/test_modify_on_missing_is_an_add.py
+++ b/tests/unit/test_modify_on_missing_is_an_add.py
@@ -1,0 +1,114 @@
+"""A plan's "Modify" for a file the base does not have is an Add (#2879).
+
+boostgauge #4, `run-issue4-193821`: the requirements gate, the design and the
+spec all passed, and the implementation stage halted in 5.2 seconds:
+
+    [GUARD] Modify target does not exist: src/boostgauge/collector.py
+    [GUARD] Modify target does not exist: src/boostgauge/collectors/windows.py
+    [GUARD] Modify target does not exist: tests/unit/test_collector.py
+    [GUARD] Modify target does not exist: tests/integration/test_windows_sweep_crosscheck.py
+    [GUARD] Modify target does not exist: tests/benchmark/test_sweep_cost.py
+
+The base, `hardening-run-20`, is Phase 2's from-seed branch and has none of
+the five; they are #4's own deliverable. The operator ruled (#2736) that the
+LLD's file list is a plan, not a contract. The change type is the same kind
+of claim, and the truth is on disk -- the inverse of `resolve_change_type`,
+which turns an Add whose file the base ships into a Modify.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation import orchestrator
+
+RUN_26_PLAN = [
+    {"path": "src/boostgauge/collector.py", "change_type": "Modify"},
+    {"path": "src/boostgauge/collectors/windows.py", "change_type": "Modify"},
+    {"path": "tests/unit/test_collector.py", "change_type": "Modify"},
+    {"path": "tests/integration/test_windows_sweep_crosscheck.py", "change_type": "Modify"},
+    {"path": "tests/benchmark/test_sweep_cost.py", "change_type": "Modify"},
+]
+
+
+@pytest.fixture
+def seed_base(tmp_path):
+    """hardening-run-20's shape: config, telltale, a skin, no collector."""
+    (tmp_path / "src" / "boostgauge" / "skins").mkdir(parents=True)
+    (tmp_path / "tests" / "unit").mkdir(parents=True)
+    for rel in ("src/boostgauge/__init__.py", "src/boostgauge/config.py",
+                "src/boostgauge/telltale.py", "src/boostgauge/skins/stingray.py",
+                "tests/unit/test_config.py"):
+        (tmp_path / rel).write_text("# base\n", encoding="utf-8")
+    return tmp_path
+
+
+class TestTheGuard:
+    def test_the_five_modifies_become_adds_with_no_error(self, seed_base, capsys):
+        plan = [dict(spec) for spec in RUN_26_PLAN]
+
+        errors = orchestrator.validate_files_to_modify(plan, seed_base)
+
+        assert errors == [], errors
+        assert [spec["change_type"] for spec in plan] == ["Add"] * 5
+        out = capsys.readouterr().out
+        assert out.count("says Modify but the base has no") == 5
+        assert "#2736" in out
+
+    def test_parent_directories_are_created_for_the_coerced_adds(self, seed_base):
+        plan = [dict(spec) for spec in RUN_26_PLAN]
+
+        orchestrator.validate_files_to_modify(plan, seed_base)
+
+        assert (seed_base / "src" / "boostgauge" / "collectors").is_dir()
+        assert (seed_base / "tests" / "integration").is_dir()
+        assert (seed_base / "tests" / "benchmark").is_dir()
+
+    def test_a_modify_whose_file_exists_stays_a_modify(self, seed_base, capsys):
+        plan = [{"path": "src/boostgauge/telltale.py", "change_type": "Modify"}]
+
+        errors = orchestrator.validate_files_to_modify(plan, seed_base)
+
+        assert errors == []
+        assert plan[0]["change_type"] == "Modify"
+        assert "says Modify" not in capsys.readouterr().out
+
+    def test_a_delete_whose_target_is_missing_is_still_an_error(self, seed_base):
+        """Unchanged: there is nothing to coerce a Delete into."""
+        plan = [{"path": "src/boostgauge/gone.py", "change_type": "Delete"}]
+
+        errors = orchestrator.validate_files_to_modify(plan, seed_base)
+
+        assert errors == ["Delete target does not exist: src/boostgauge/gone.py"]
+
+
+class TestTheStageNoLongerHaltsOnIt:
+    def test_implement_code_proceeds_to_generation(self, seed_base, capsys):
+        generated: list[str] = []
+
+        def fake_regen(filepath, **kwargs):
+            generated.append(filepath)
+            return "# generated\n", True
+
+        state = {
+            "repo_root": str(seed_base),
+            "lld_content": "## 2.1 Files\n",
+            "files_to_modify": [dict(spec) for spec in RUN_26_PLAN],
+            "test_files": ["tests/unit/test_collector.py"],
+            "iteration_count": 0,
+            "audit_dir": str(seed_base / "audit"),
+        }
+        with patch.object(orchestrator, "generate_file_with_retry", fake_regen), \
+             patch.object(orchestrator, "record_iteration_cost", return_value=0), \
+             patch.object(orchestrator, "get_cumulative_cost", return_value=0.0):
+            try:
+                result = orchestrator.implement_code(state)
+            except Exception:
+                result = {}
+
+        out = capsys.readouterr().out
+        assert "GUARD:" not in str(result.get("error_message", ""))
+        assert "file path(s) in LLD do not match" not in out
+        assert generated, "the stage must reach generation instead of halting on the guard"


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-193821` (2026-09-05 19:38). The requirements gate passed, the design passed on review 2, the spec passed on review 4 — the first run today to clear all three. The implementation stage then halted in **5.2 seconds**:

```
[GUARD] Modify target does not exist: src/boostgauge/collector.py
[GUARD] Modify target does not exist: src/boostgauge/collectors/windows.py
[GUARD] Modify target does not exist: tests/unit/test_collector.py
[GUARD] Modify target does not exist: tests/integration/test_windows_sweep_crosscheck.py
[GUARD] Modify target does not exist: tests/benchmark/test_sweep_cost.py
GUARD: 5 file path(s) in LLD do not match the repository structure.
```

The base, `hardening-run-20`, is Phase 2's from-seed branch: `config.py`, `telltale.py`, `skins/stingray.py`, and no collector. The five files are #4's own deliverable. The design called them Modify — because the issue's revision history describes the collector shipped on `main`, and the drafter read that as the base (#2880, filed).

## Why the guard is the thing to change

`validate_files_to_modify` (#445) hard-fails a Modify whose target is absent. Its reading of the tree is correct; its response is the one the operator retired: on 2026-09-04 (#2736) he ruled that *the LLD's file list is a plan, not a contract*, and `path_advisory` went from a refusal to a notice on that ruling. The change type is the same kind of claim — the plan's guess about the base — and the truth is on disk.

The inverse already exists. `resolve_change_type` (#2032/#2033) turns an Add whose file the base ships into a Modify, "so the earlier phase's work is extended rather than replaced." A Modify whose file the base lacks is an Add, for the same reason in the other direction: there is nothing to extend, and refusing leaves a passed design and spec with no implementation.

## The change

A Modify whose target does not exist is coerced to Add in the spec dict (so the loop implements it as one), its parent directories are created, and the coercion is printed:

```
[PLAN] says Modify but the base has no src/boostgauge/collector.py; implementing as Add (#2736: the file list is a plan, not a contract)
```

A Modify whose file exists is untouched. A Delete whose target is missing stays an error — there is nothing to coerce it into.

## Tests

`tests/unit/test_modify_on_missing_is_an_add.py`, five cases, against a tree shaped like `hardening-run-20`:

- run 26's five Modifies become five Adds with no error and five printed notes;
- their parent directories exist afterwards;
- a Modify whose file exists stays a Modify, silently;
- a Delete whose target is missing is still an error;
- `implement_code` driven end to end on the same plan reaches generation instead of halting on the guard.

`test_implement_code_path_validation.py` — the #445 suite — is updated where it asserted the old refusal (see the diff); its Add and Delete cases are unchanged.

Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
