### PR TITLE
fix: a test that passes is the contract, and a revision keeps it as written while it fixes the ones that fail (Closes #2905)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
@@ -1,0 +1,150 @@
+"""A passing test is the contract; a revision keeps it as written (#2905).
+
+boostgauge #4, `run-issue4-042724` (2026-09-06 04:27): N4c had taken coverage
+from 91 % to 99 % and left two of its thirteen tests failing. Fixing those
+two, N4's edit script patched `tests/unit/test_collector.py` in iterations 2
+and 4 (`Applied 2 edit(s); 97% preserved`, `Applied 3 edit(s); 98% preserved`)
+and the patches rewrote assertions of tests that were passing: `test_req_13`
+went from `pytest.raises(NotImplementedError)` to `pytest.raises(OSError)`,
+req_9 and req_10 gained a `WindowsCollector(ntdll=mock)` the constructor never
+had. Each per-file call sees only its file and the failure corpus (#2851), so
+the test file's call could not know the implementation's call had added
+`nt_query=` instead. The loop measured 49 -> 47 -> 48 of 51 and ran out at
+the cap, three tests below where it started.
+
+#2064's freeze holds the tests for the one iteration after a repeated failing
+set; #2866 stops a *failed* patch from regenerating a test file. Neither speaks
+to a patch that succeeds and changes a passing test. This does: in a revision,
+every test that passed at the measurement the worktree reflects is kept byte
+for byte -- decorators included -- and one the patch deleted comes back. The
+failing tests, and any new ones, are the patch's to change. The implementation
+conforms to the passing tests, never the reverse.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import NamedTuple
+
+#: A `-v` outcome line: `tests/unit/test_x.py::TestA::test_b[case] PASSED [ 12%]`.
+_VERBOSE_PASSED = re.compile(r"^(?P<nodeid>\S+::\S+)\s+PASSED\b", re.MULTILINE)
+
+
+def passing_test_names(pytest_output: str) -> set[str]:
+    """Bare names of the tests a `-v` run reported PASSED.
+
+    The same bare form `_extract_failed_test_names` uses for failures:
+    `tests/unit/test_x.py::TestA::test_b[case] PASSED` -> `test_b`.
+    """
+    names: set[str] = set()
+    for match in _VERBOSE_PASSED.finditer(pytest_output):
+        leaf = match.group("nodeid").rsplit("::", 1)[-1]
+        names.add(leaf.split("[", 1)[0])
+    return names
+
+
+class Kept(NamedTuple):
+    source: str
+    #: Tests whose edited text was replaced with their prior text.
+    restored: list[str]
+    #: Tests the edit had deleted, put back where they were.
+    returned: list[str]
+
+
+_Function = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _test_functions(tree: ast.Module) -> dict[str, tuple[_Function, ast.ClassDef | None]]:
+    """Test functions by key: `name` at module level, `Class.name` in a class."""
+    found: dict[str, tuple[_Function, ast.ClassDef | None]] = {}
+    for node in tree.body:
+        if isinstance(node, _Function) and node.name.startswith("test"):
+            found[node.name] = (node, None)
+        elif isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, _Function) and item.name.startswith("test"):
+                    found[f"{node.name}.{item.name}"] = (item, node)
+    return found
+
+
+def _span(node: ast.AST) -> tuple[int, int]:
+    """1-based inclusive line span, decorators included."""
+    first = min([node.lineno, *(d.lineno for d in getattr(node, "decorator_list", []))])
+    return first, node.end_lineno or node.lineno
+
+
+def _text(lines: list[str], span: tuple[int, int]) -> str:
+    return "\n".join(lines[span[0] - 1:span[1]])
+
+
+def keep_passing_tests_as_written(before: str, after: str, passing: set[str]) -> Kept:
+    """`after`, with every passing test's text taken from `before`.
+
+    A passing test whose text the edit changed gets its prior text back in
+    place. One the edit deleted is put back: at the end of the module, or at
+    the end of its class when the class is still there (a class the edit
+    removed takes its methods with it -- they are not re-homed).
+
+    `after` is returned untouched when there is nothing to keep, or when
+    either side does not parse: a file that does not parse is the syntax
+    gate's finding, and a guess at its functions would be noise on top.
+    """
+    if not passing or before == after:
+        return Kept(after, [], [])
+    try:
+        before_tree = ast.parse(before)
+        after_tree = ast.parse(after)
+    except SyntaxError:
+        # fail-open: an unparseable side is reported by the syntax gate that
+        # runs on the written file; this keeps nothing rather than guessing.
+        return Kept(after, [], [])
+
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    before_tests = _test_functions(before_tree)
+    after_tests = _test_functions(after_tree)
+    after_classes = {
+        node.name: node for node in after_tree.body if isinstance(node, ast.ClassDef)
+    }
+
+    # Edits as (start_index, end_index_exclusive, replacement_lines), applied
+    # bottom-up so earlier indices stay valid.
+    edits: list[tuple[int, int, list[str]]] = []
+    trailing: list[str] = []
+    restored: list[str] = []
+    returned: list[str] = []
+    for key, (node, owner) in before_tests.items():
+        if node.name not in passing:
+            continue
+        prior = _text(before_lines, _span(node))
+        current = after_tests.get(key)
+        if current is not None:
+            span = _span(current[0])
+            if _text(after_lines, span) != prior:
+                edits.append((span[0] - 1, span[1], prior.splitlines()))
+                restored.append(node.name)
+            continue
+        if owner is None:
+            trailing.append(prior)
+            returned.append(node.name)
+            continue
+        home = after_classes.get(owner.name)
+        if home is None:
+            continue
+        end = home.end_lineno or home.lineno
+        edits.append((end, end, ["", *prior.splitlines()]))
+        returned.append(node.name)
+
+    if not restored and not returned:
+        return Kept(after, [], [])
+
+    out = list(after_lines)
+    for start, end, lines in sorted(edits, key=lambda e: e[0], reverse=True):
+        out[start:end] = lines
+    source = "\n".join(out)
+    if trailing:
+        source = source.rstrip("\n") + "\n\n\n" + "\n\n\n".join(trailing)
+    if after.endswith("\n"):
+        source = source.rstrip("\n") + "\n"
+    return Kept(source, restored, returned)

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -45,6 +45,7 @@ from .claude_client import (
     call_claude_for_file,
 )
 from .context import estimate_context_tokens
+from .keep_passing_tests import keep_passing_tests_as_written, passing_test_names
 from .parsers import (
     detect_summary_response,
     extract_code_block,
@@ -1073,6 +1074,30 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
                 )
             # Note: generate_file_with_retry raises ImplementationError on
             # failure, so if we get here, code is valid
+
+        # #2905: a passing test is the contract. run-issue4-042724's patches to
+        # the test file fixed two failing coverage tests and rewrote three
+        # passing ones -- the loop then spent its iterations undoing its own
+        # edits to its own contract. In a revision, every test that passed at
+        # the measurement the worktree reflects keeps its prior text; the
+        # failing tests and any new ones are the patch's to change.
+        prior_text = edit_script_content or existing_content
+        if (
+            iteration_count > 0
+            and prior_text
+            and filepath.replace("\\", "/").split("/")[0] in ("tests", "test")
+        ):
+            contract = set(state.get("contract_tests") or []) or passing_test_names(
+                green_phase_output
+            )
+            kept = keep_passing_tests_as_written(prior_text, code, contract)
+            if kept.restored or kept.returned:
+                code = kept.source
+                names = ", ".join(sorted(kept.restored + kept.returned))
+                print(
+                    f"        [N4] kept {len(kept.restored) + len(kept.returned)} "
+                    f"passing test(s) as written in {filepath}: {names} (#2905)"
+                )
 
         # Write file (atomic: write to temp, then rename)
         temp_path = target_path.with_suffix(target_path.suffix + ".tmp")

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -29,6 +29,9 @@ from assemblyzero.workflows.testing.audit import (
 from assemblyzero.workflows.testing.checkpoints import record_measurement
 from assemblyzero.workflows.testing.circuit_breaker import check_circuit_breaker
 from assemblyzero.workflows.testing.nodes.e2e_validation import _extract_failed_test_names
+from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+    passing_test_names,
+)
 # `route_by_exit_code` is deliberately NOT imported here (#2671). It was, and
 # was never called: the exit-code branching that actually runs is inline below
 # on these same constants. Removing the import is the lint fix; the two
@@ -1548,7 +1551,7 @@ COVERAGE_IMPROVEMENT_THRESHOLD = 1.0
 
 def _hill_climb(
     state, repo_root, passed_count, coverage_achieved, current_green_failures,
-    updates,
+    updates, passing_tests: list[str] | None = None,
 ) -> None:
     """Never revise from a state worse than the best one seen (#2050).
 
@@ -1576,6 +1579,10 @@ def _hill_climb(
 
     best = state.get("best_iteration") or None
     score = (passed_count, coverage_achieved)
+    # #2905: the tests N4 must keep as written are the ones that passed at
+    # the measurement the worktree reflects -- this one, unless the restore
+    # below puts the best iteration's files back, in which case the best's.
+    updates["contract_tests"] = sorted(passing_tests or [])
     best_score = (
         (best.get("passed", -1), best.get("coverage", -1.0)) if best else None
     )
@@ -1601,6 +1608,7 @@ def _hill_climb(
             "passed": passed_count,
             "coverage": coverage_achieved,
             "green_failures": list(current_green_failures or []),
+            "passing": sorted(passing_tests or []),
             "files": manifest,
         }
         print(
@@ -1621,6 +1629,7 @@ def _hill_climb(
         updates["previous_passed"] = best.get("passed", passed_count)
         updates["previous_coverage"] = best.get("coverage", coverage_achieved)
         updates["previous_green_failures"] = best.get("green_failures", [])
+        updates["contract_tests"] = list(best.get("passing") or [])
         print(
             f"    [N5] iteration regressed ({passed_count} passing at "
             f"{coverage_achieved:.1f}% vs best {best.get('passed')} at "
@@ -2610,6 +2619,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "count_plateau_strikes": plateau_strikes,
                 "identity_plateau_strikes": identity_strikes,
                 "freeze_tests": True,
+                # #2905: no restore on this path; the latest output governs.
+                "contract_tests": [],
             }
 
         # Stagnation check: one shared decision, see coverage_has_stagnated,
@@ -2691,7 +2702,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         # #2841: a granted cap must reach the routers, which read it from state.
         updates["max_iterations"] = max_iterations
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
-                    current_green_failures, updates)
+                    current_green_failures, updates,
+                    passing_tests=sorted(passing_test_names(output)))
         return updates
 
     # Check coverage
@@ -2808,7 +2820,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "max_iterations": max_iterations,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
-                    current_green_failures, updates)
+                    current_green_failures, updates,
+                    passing_tests=sorted(passing_test_names(output)))
         return updates
 
     # Success: all tests pass and coverage meets target

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -220,6 +220,11 @@ class TestingWorkflowState(TypedDict, total=False):
     # when True, N4 must not rewrite test files; they are the frozen contract.
     identity_plateau_strikes: int
     freeze_tests: bool
+    # #2905: the tests that passed at the measurement the worktree reflects --
+    # the best iteration's after a hill-climb restore, else the latest run's.
+    # N4 keeps each of them as written when it revises a test file. Empty
+    # means "read the latest green output".
+    contract_tests: list[str]
     # #2546: green-phase iterations where pytest collected ZERO tests. A zero
     # needs a denominator: one zero-collection routes to the implement loop
     # as a named collection-repair task; a second halts naming the collection

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
-    "files_scanned": 303,
-    "sites_examined": 9196,
-    "findings_total": 552
+    "files_scanned": 304,
+    "sites_examined": 9219,
+    "findings_total": 553
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage rises above this, and when model_output_halt_rows differs from it in EITHER direction (#2759). A row that stops halting, or that leaves the model-output category, lowers the number in the same PR -- so the denominator is never stale. Raise either only with an operator ruling named in the row's created_by or justified_by, in the same PR.",
   "measured_against": {
-    "files_scanned": 177,
+    "files_scanned": 178,
     "halt_sites": 142,
     "gates": 93
   },

--- a/tests/unit/test_n4_keeps_passing_tests.py
+++ b/tests/unit/test_n4_keeps_passing_tests.py
@@ -1,0 +1,350 @@
+"""A passing test is the contract; a revision keeps it as written (#2905).
+
+boostgauge #4, `run-issue4-042724` (2026-09-06 04:27). N4c took coverage from
+91 % to 99 % and left two of its thirteen tests failing. N4's patches to
+`tests/unit/test_collector.py` in iterations 2 and 4 fixed those and rewrote
+three passing tests on the way: `test_req_13` went from
+`pytest.raises(NotImplementedError)` to `pytest.raises(OSError)`; req_9 and
+req_10 gained `WindowsCollector(ntdll=mock)`, a keyword the constructor never
+had. The loop measured 49 -> 47 -> 48 of 51 and ran out at the cap.
+
+Every case here is the shape of that file: a test that passed keeps its text,
+a test that failed is the patch's to change, a deleted passing test comes
+back, and the verifier tells the implementer which tests those are.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+    Kept,
+    keep_passing_tests_as_written,
+    passing_test_names,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import _hill_climb
+from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+# run 32's test file, reduced: three passing spec tests and one failing
+# coverage test the patch is entitled to change.
+RUN_32 = '''\
+"""Tests for the collector."""
+import unittest.mock
+
+import pytest
+
+from boostgauge.collector import make_collector
+from boostgauge.collectors.windows import WindowsCollector
+
+
+def test_req_9_buffer_growth_on_mismatch(monkeypatch):
+    c = WindowsCollector(sweep=lambda: [])
+    initial_len = len(c._buffer)
+    c.nt_sweep()
+    assert len(c._buffer) > initial_len
+
+
+@pytest.mark.parametrize("status", [-1, -1073741820])
+def test_req_10_oserror_fallback(status):
+    c = WindowsCollector(sweep=lambda: [])
+    with pytest.raises(OSError):
+        c.nt_sweep()
+
+
+def test_req_13_mac_linux_raises_notimplemented(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(NotImplementedError):
+        make_collector()
+
+
+def test_collect_with_thresholds_computes_composite():
+    c = WindowsCollector()
+    assert c.collect().composite == 0.0
+'''
+
+# iteration 4's patch: the failing coverage test fixed, and the three
+# passing tests rewritten on the way.
+RUN_39 = '''\
+"""Tests for the collector."""
+import unittest.mock
+
+import pytest
+
+from boostgauge.collector import make_collector
+from boostgauge.collectors.windows import WindowsCollector
+
+
+def test_req_9_buffer_growth_on_mismatch(monkeypatch):
+    mock_ntdll = unittest.mock.MagicMock()
+    mock_ntdll.NtQuerySystemInformation.side_effect = [-1073741820, 0]
+    c = WindowsCollector(ntdll=mock_ntdll)
+    initial_len = len(c._buffer)
+    c.nt_sweep()
+    assert len(c._buffer) > initial_len
+
+
+@pytest.mark.parametrize("status", [-1, -1073741820])
+def test_req_10_oserror_fallback(status):
+    mock_ntdll = unittest.mock.MagicMock()
+    mock_ntdll.NtQuerySystemInformation.return_value = status
+    c = WindowsCollector(ntdll=mock_ntdll)
+    with pytest.raises(OSError):
+        c.nt_sweep()
+
+
+def test_req_13_mac_linux_raises_notimplemented(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(OSError):
+        make_collector()
+
+
+def test_collect_with_thresholds_computes_composite():
+    c = WindowsCollector(sweep=lambda: [])
+    assert c.collect().composite == 10.0
+'''
+
+PASSING = {
+    "test_req_9_buffer_growth_on_mismatch",
+    "test_req_10_oserror_fallback",
+    "test_req_13_mac_linux_raises_notimplemented",
+}
+
+GREEN_OUTPUT = """\
+tests/unit/test_collector.py::test_req_9_buffer_growth_on_mismatch PASSED [ 25%]
+tests/unit/test_collector.py::test_req_10_oserror_fallback[-1] PASSED   [ 50%]
+tests/unit/test_collector.py::test_req_10_oserror_fallback[-1073741820] PASSED [ 62%]
+tests/unit/test_collector.py::test_req_13_mac_linux_raises_notimplemented PASSED [ 75%]
+tests/unit/test_collector.py::test_collect_with_thresholds_computes_composite FAILED [100%]
+tests/unit/test_other.py::TestGroup::test_inside_a_class PASSED          [100%]
+
+=================================== FAILURES ===================================
+FAILED tests/unit/test_collector.py::test_collect_with_thresholds_computes_composite - assert 0.0 == 10.0
+"""
+
+
+def _function_text(source: str, name: str) -> str:
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            first = min([node.lineno, *(d.lineno for d in node.decorator_list)])
+            return "\n".join(lines[first - 1:node.end_lineno])
+    raise AssertionError(f"{name} not in source")
+
+
+class TestRun39sPatch:
+    def test_the_three_passing_tests_keep_run_32s_text(self):
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+        for name in PASSING:
+            assert _function_text(kept.source, name) == _function_text(RUN_32, name)
+        assert sorted(kept.restored) == sorted(PASSING)
+        assert kept.returned == []
+
+    def test_req_13_asserts_notimplementederror_again(self):
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+        body = _function_text(kept.source, "test_req_13_mac_linux_raises_notimplemented")
+        assert "pytest.raises(NotImplementedError)" in body
+        assert "ntdll" not in kept.source
+
+    def test_the_failing_coverage_test_keeps_the_patch(self):
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+        body = _function_text(kept.source, "test_collect_with_thresholds_computes_composite")
+        assert body == _function_text(RUN_39, "test_collect_with_thresholds_computes_composite")
+
+    def test_the_decorator_travels_with_the_test(self):
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+        body = _function_text(kept.source, "test_req_10_oserror_fallback")
+        assert body.startswith("@pytest.mark.parametrize")
+        assert kept.source.count("@pytest.mark.parametrize") == 1
+
+    def test_the_result_still_parses_and_ends_with_a_newline(self):
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+        ast.parse(kept.source)
+        assert kept.source.endswith("\n")
+        assert not kept.source.endswith("\n\n")
+
+    def test_the_names_come_from_the_green_output(self):
+        names = passing_test_names(GREEN_OUTPUT)
+
+        assert names == PASSING | {"test_inside_a_class"}
+
+    def test_with_the_output_as_the_contract_the_result_is_the_same(self):
+        by_output = keep_passing_tests_as_written(
+            RUN_32, RUN_39, passing_test_names(GREEN_OUTPUT),
+        )
+
+        assert by_output == keep_passing_tests_as_written(RUN_32, RUN_39, PASSING)
+
+
+class TestNothingToKeep:
+    def test_no_passing_tests_means_no_change(self):
+        assert keep_passing_tests_as_written(RUN_32, RUN_39, set()) == Kept(RUN_39, [], [])
+
+    def test_an_identical_file_is_untouched(self):
+        assert keep_passing_tests_as_written(RUN_32, RUN_32, PASSING) == Kept(RUN_32, [], [])
+
+    def test_a_patch_that_left_the_passing_tests_alone_is_untouched(self):
+        only_the_failing_one = RUN_32.replace(
+            "assert c.collect().composite == 0.0",
+            "assert c.collect().composite == 10.0",
+        )
+
+        kept = keep_passing_tests_as_written(RUN_32, only_the_failing_one, PASSING)
+
+        assert kept == Kept(only_the_failing_one, [], [])
+
+    def test_an_unparseable_patch_is_left_for_the_syntax_gate(self):
+        broken = RUN_39 + "\ndef broken(:\n"
+
+        assert keep_passing_tests_as_written(RUN_32, broken, PASSING) == Kept(broken, [], [])
+
+    def test_an_unparseable_prior_keeps_nothing(self):
+        assert keep_passing_tests_as_written("def x(:\n", RUN_39, PASSING) == Kept(RUN_39, [], [])
+
+
+class TestADeletedPassingTestComesBack:
+    def test_a_module_level_test_is_appended(self):
+        without_req_13 = RUN_39.replace(
+            _function_text(RUN_39, "test_req_13_mac_linux_raises_notimplemented") + "\n\n\n",
+            "",
+        )
+        assert "test_req_13" not in without_req_13
+
+        kept = keep_passing_tests_as_written(RUN_32, without_req_13, PASSING)
+
+        assert kept.returned == ["test_req_13_mac_linux_raises_notimplemented"]
+        assert _function_text(kept.source, "test_req_13_mac_linux_raises_notimplemented") == \
+            _function_text(RUN_32, "test_req_13_mac_linux_raises_notimplemented")
+        ast.parse(kept.source)
+
+    def test_a_method_goes_back_into_its_class(self):
+        before = (
+            "class TestGroup:\n"
+            "    def test_kept(self):\n"
+            "        assert 1\n"
+            "\n"
+            "    def test_gone(self):\n"
+            "        assert 2\n"
+        )
+        after = (
+            "class TestGroup:\n"
+            "    def test_kept(self):\n"
+            "        assert 1\n"
+        )
+
+        kept = keep_passing_tests_as_written(before, after, {"test_kept", "test_gone"})
+
+        assert kept.returned == ["test_gone"]
+        tree = ast.parse(kept.source)
+        methods = [n.name for n in tree.body[0].body if isinstance(n, ast.FunctionDef)]
+        assert methods == ["test_kept", "test_gone"]
+
+    def test_a_method_whose_class_is_gone_is_not_re_homed(self):
+        before = "class TestGroup:\n    def test_gone(self):\n        assert 2\n"
+        after = "def test_new():\n    assert 3\n"
+
+        kept = keep_passing_tests_as_written(before, after, {"test_gone"})
+
+        assert kept == Kept(after, [], [])
+
+    def test_a_changed_method_is_restored_in_place(self):
+        before = "class TestGroup:\n    def test_kept(self):\n        assert 1\n"
+        after = "class TestGroup:\n    def test_kept(self):\n        assert 99\n"
+
+        kept = keep_passing_tests_as_written(before, after, {"test_kept"})
+
+        assert kept.restored == ["test_kept"]
+        assert kept.source == before
+
+
+class TestTheVerifierNamesTheContract:
+    """`_hill_climb` records the passing set and hands N4 the one that matches
+    the files in the worktree: the best's after a restore, else the latest."""
+
+    @pytest.fixture
+    def tree(self, tmp_path):
+        repo = tmp_path / "worktree"
+        (repo / "src").mkdir(parents=True)
+        (repo / "tests").mkdir()
+        impl = repo / "src" / "collector.py"
+        test = repo / "tests" / "test_collector.py"
+        impl.write_text("BEST = 1\n", encoding="utf-8")
+        test.write_text(RUN_32, encoding="utf-8")
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        return repo, impl, test, audit
+
+    @staticmethod
+    def _state(repo, impl, test, audit, best=None):
+        return {
+            "implementation_files": [str(impl)],
+            "test_files": [str(test)],
+            "audit_dir": str(audit),
+            "best_iteration": best,
+        }
+
+    def test_a_new_best_records_its_passing_tests(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+
+        _hill_climb(self._state(repo, impl, test, audit), repo, 49, 99.0, ["t_x"],
+                    updates, passing_tests=sorted(PASSING))
+
+        assert updates["best_iteration"]["passing"] == sorted(PASSING)
+        assert updates["contract_tests"] == sorted(PASSING)
+
+    def test_a_restore_hands_n4_the_bests_passing_tests(self, tree):
+        repo, impl, test, audit = tree
+        first = {}
+        _hill_climb(self._state(repo, impl, test, audit), repo, 49, 99.0, ["t_x"],
+                    first, passing_tests=sorted(PASSING))
+        best = first["best_iteration"]
+        impl.write_text("WORSE = 1\n", encoding="utf-8")
+        worse = {}
+
+        _hill_climb(self._state(repo, impl, test, audit, best), repo, 47, 99.0,
+                    ["t_x", "t_y", "test_req_13_mac_linux_raises_notimplemented"],
+                    worse, passing_tests=["test_req_9_buffer_growth_on_mismatch"])
+
+        assert worse["contract_tests"] == sorted(PASSING)
+        assert impl.read_text(encoding="utf-8") == "BEST = 1\n"
+
+    def test_an_equal_iteration_hands_n4_the_latest_passing_tests(self, tree):
+        repo, impl, test, audit = tree
+        first = {}
+        _hill_climb(self._state(repo, impl, test, audit), repo, 49, 99.0, ["t_x"],
+                    first, passing_tests=sorted(PASSING))
+        best = first["best_iteration"]
+        latest = ["test_a", "test_b"]
+        same = {}
+
+        _hill_climb(self._state(repo, impl, test, audit, best), repo, 49, 99.0,
+                    ["t_y"], same, passing_tests=latest)
+
+        assert same["contract_tests"] == latest
+        assert "best_iteration" not in same
+
+    def test_the_channel_is_declared(self):
+        assert "contract_tests" in TestingWorkflowState.__annotations__
+
+
+def test_the_implementer_keeps_passing_tests_before_it_writes():
+    """Structural: the guard sits between the model's code and the write."""
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "assemblyzero" / "workflows" / "testing" / "nodes" / "implementation"
+        / "orchestrator.py"
+    ).read_text(encoding="utf-8")
+
+    guard = source.index("keep_passing_tests_as_written(prior_text, code, contract)")
+    write = source.index("# Write file (atomic: write to temp, then rename)")
+    assert guard < write
+    assert "(#2905)" in source

--- a/tests/unit/test_node_modules_supply_nodes.py
+++ b/tests/unit/test_node_modules_supply_nodes.py
@@ -63,6 +63,10 @@ SUPPLIES_NO_NODE_EXEMPTIONS: dict[str, str] = {
     "parsers": "response parsers imported by implementation/orchestrator",
     "edit_script": "edit-block helpers imported by generate_spec",
     "edit_script_fix": "edit-block repair helpers imported by generate_spec",
+    "keep_passing_tests": (
+        "passing-test contract helpers imported by implementation/orchestrator "
+        "and verify_phases (#2905)"
+    ),
     "lld_revision": "revision helpers imported by generate_draft",
     "ponder_rules": "rule table imported by the ponder node",
     "retry_prompt_builder": "retry prompts imported by generate_spec",


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-042724` (2026-09-06 04:27). N4c had just taken coverage from 91 % to 99 % (#2903) and left two of its thirteen tests failing. The green loop ran four more iterations to fix those two and ended at the cap with three *different* tests failing:

```
[N5] Results: 49 passed, 2 failed | Coverage: 99.0%
[N5] same 2 test(s) failing again — freezing tests as the contract (strike 1)
[N5] Results: 47 passed, 4 failed | Coverage: 99.0%
[N5] iteration regressed (47 passing at 99.0% vs best 49 at 99.0%) — restored 6 file(s)
[N5] Results: 48 passed, 3 failed | Coverage: 99.0%
[ERROR] Max iterations (5) reached with 3 failures
```

`test_req_9`, `test_req_10` and `test_req_13` had passed at every measurement since run 32. The test side moved: run 32's tree has `test_req_13` asserting `NotImplementedError` and no `ntdll=` anywhere; run 39's asserts `OSError` and constructs `WindowsCollector(ntdll=mock)`, a keyword the constructor never had. N4's edit script patched `tests/unit/test_collector.py` in iterations 2 and 4 (`Applied 2 edit(s); 97% preserved`, `Applied 3 edit(s); 98% preserved`) — small patches aimed at the failing coverage tests that also rewrote passing ones. Each per-file call sees only its file and the failure corpus (#2851), so the test file's call invented `ntdll=` without knowing the implementation's call had added `nt_query=`.

#2064's freeze holds the tests for the one iteration after a repeated failing set; #2866 stops a *failed* patch from regenerating a test file. Neither speaks to a patch that succeeds and changes a passing test.

## The change

- `nodes/implementation/keep_passing_tests.py`: `passing_test_names(output)` reads the `-v` PASSED lines into the bare form the failure extractor uses; `keep_passing_tests_as_written(before, after, passing)` returns `after` with every passing test's text taken from `before`, decorators included — a changed one restored in place, a deleted one put back at the end of the module or of its class. Untouched when nothing is to keep or either side does not parse (the syntax gate's finding, with a ruling).
- `verify_phases._hill_climb` records `passing` on the best-iteration snapshot and sets `contract_tests` in the node's updates: the latest measurement's passing set, or the best's after a restore. The freeze return sets it empty, meaning "read the latest green output".
- `state.TestingWorkflowState.contract_tests` declares the channel (#2847's lesson).
- `orchestrator.implement_code`: in a revision iteration, before writing a file under `tests/`, keeps the contract tests as written and prints `[N4] kept N passing test(s) as written in <file>: …`.

## Tests

`tests/unit/test_n4_keeps_passing_tests.py`, twenty-one cases on run 39's file:

- the three passing tests keep run 32's text; `test_req_13` asserts `NotImplementedError` again and `ntdll` is gone; the failing coverage test keeps the patch; the parametrize decorator travels with its test; the result parses and ends with one newline; the names come from the green output and give the same result;
- nothing to keep: no passing set, an identical file, a patch that left passing tests alone, an unparseable patch, an unparseable prior;
- a deleted module-level test is appended; a deleted method goes back into its class; a method whose class is gone is not re-homed; a changed method is restored in place;
- the verifier: a new best records its passing tests and names them as the contract; a restore hands N4 the best's; an equal iteration hands N4 the latest's; the channel is declared;
- structural: the guard sits between the model's code and the atomic write.

`test_hill_climb.py`, `test_restore_best_on_failure.py`, `test_impl_invoke_payload_is_declared.py` and the import-cycle guard pass unchanged. `ruff` clean; the fail-open audit passes with the one ruled site.

**Before:** on the unfixed tree the module does not exist and N4 writes the patched file as returned — run 39's three rewrites land, exactly as the log shows.

Closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
