### PR TITLE
fix: N4c appends its coverage tests to the first plan-owned test file, not the spec suite the scaffold re-emits on every resume (Closes #2908)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/augment_tests.py
+++ b/assemblyzero/workflows/testing/nodes/augment_tests.py
@@ -496,6 +496,30 @@ def build_revision_prompt(
     ])
 
 
+def coverage_target_file(
+    test_files: list[str], repo_root: Path, issue_number: int | None,
+) -> Path:
+    """The file N4c appends to: the first plan-owned test file (#2908).
+
+    Never the spec's suite while there is any other. The scaffold re-emits
+    `tests/test_issue_<N>.py` from the spec on every resume (#2709 keeps it
+    as the contract), so an addition there lasts exactly until the next
+    resume: run-issue4-131639 measured 38 of the 51 tests run 39 left,
+    because run 39's N4c had appended its thirteen to the suite. A
+    plan-owned file survives a resume (#2897 registers it) and #2905 keeps
+    its passing tests as written. Without an issue number the suite cannot
+    be named, and the first file stands as before; with only the suite in
+    the list, the suite is the only place there is.
+    """
+    if issue_number is None or not test_files:
+        return Path(test_files[0])
+    suite = (Path(repo_root) / "tests" / f"test_issue_{issue_number}.py").resolve()
+    for candidate in test_files:
+        if Path(candidate).resolve() != suite:
+            return Path(candidate)
+    return Path(test_files[0])
+
+
 def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
     """N4c: append tests targeting uncovered lines (#2327).
 
@@ -551,7 +575,8 @@ def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
     for path, ranges in uncovered.items():
         print(f"      {path}: {', '.join(ranges)}")
 
-    test_path = Path(test_files[0])
+    test_path = coverage_target_file(test_files, repo_root, state.get("issue_number"))
+    print(f"    [N4c] appending to {test_path.name} (#2908)")
     try:
         existing = test_path.read_text(encoding="utf-8")
     except OSError as err:

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 304,
-    "sites_examined": 9219,
+    "sites_examined": 9224,
     "findings_total": 553
   },
   "undeclared": [

--- a/tests/unit/test_n4c_keeps_the_suite_and_bounds_output.py
+++ b/tests/unit/test_n4c_keeps_the_suite_and_bounds_output.py
@@ -33,6 +33,7 @@ from assemblyzero.workflows.testing.nodes import augment_tests
 from assemblyzero.workflows.testing.nodes.augment_tests import (
     AUGMENT_TIMEOUT_SECONDS,
     augment_tests_for_coverage,
+    coverage_target_file,
 )
 from assemblyzero.workflows.testing.nodes.implementation import claude_client
 
@@ -540,3 +541,69 @@ class TestReached:
 
         assert _reached(before, "3 passed") == (0, 3)
         assert _reached(before, "") == (0, 3)
+
+
+class TestThePlanOwnedFileIsTheTarget:
+    """#2908: N4c appends to the first plan-owned test file, never the spec's
+    suite while there is any other. The scaffold re-emits the suite on every
+    resume (#2709), and `run-issue4-131639` measured 38 of the 51 tests run 39
+    left because run 39's thirteen had gone into the suite."""
+
+    def test_run_40s_additions_land_in_the_plan_file_not_the_suite(self, worktree):
+        with patch.object(augment_tests, "call_claude_for_file", return_value=(NEW_TESTS, "")):
+            result = augment_tests_for_coverage(_state(worktree, issue_number=4))
+
+        suite = (worktree / "tests" / "test_issue_4.py").read_text(encoding="utf-8")
+        plan_file = (worktree / "tests" / "unit" / "test_collector.py").read_text(encoding="utf-8")
+        assert "test_covers_the_error_path" not in suite
+        assert "def test_existing" in plan_file
+        assert "def test_covers_the_error_path" in plan_file
+        assert [Path(p).name for p in result["test_files"]] == [
+            "test_issue_4.py", "test_collector.py",
+            "test_windows_sweep_crosscheck.py", "test_sweep_cost.py",
+        ]
+
+    def test_the_addition_survives_the_scaffold_re_emitting_the_suite(self, worktree):
+        original_suite = (worktree / "tests" / "test_issue_4.py").read_text(encoding="utf-8")
+        with patch.object(augment_tests, "call_claude_for_file", return_value=(NEW_TESTS, "")):
+            augment_tests_for_coverage(_state(worktree, issue_number=4))
+
+        # What the resume's scaffold stage does to the suite (#2709).
+        (worktree / "tests" / "test_issue_4.py").write_text(original_suite, encoding="utf-8")
+
+        plan_file = (worktree / "tests" / "unit" / "test_collector.py").read_text(encoding="utf-8")
+        assert "def test_covers_the_error_path" in plan_file
+
+    def test_with_only_the_suite_the_suite_is_extended(self, worktree):
+        state = _state(
+            worktree, issue_number=4,
+            test_files=[str(worktree / "tests" / "test_issue_4.py")],
+        )
+        with patch.object(augment_tests, "call_claude_for_file", return_value=(NEW_TESTS, "")):
+            augment_tests_for_coverage(state)
+
+        suite = (worktree / "tests" / "test_issue_4.py").read_text(encoding="utf-8")
+        assert "def test_covers_the_error_path" in suite
+
+    def test_the_suite_is_skipped_wherever_it_sits(self, worktree):
+        files = [
+            str(worktree / "tests" / "unit" / "test_collector.py"),
+            str(worktree / "tests" / "test_issue_4.py"),
+        ]
+
+        assert coverage_target_file(files, worktree, 4).name == "test_collector.py"
+        assert coverage_target_file(files[::-1], worktree, 4).name == "test_collector.py"
+
+    def test_without_an_issue_number_the_first_file_stands(self, worktree):
+        files = [
+            str(worktree / "tests" / "test_issue_4.py"),
+            str(worktree / "tests" / "unit" / "test_collector.py"),
+        ]
+
+        assert coverage_target_file(files, worktree, None).name == "test_issue_4.py"
+
+    def test_it_says_which_file(self, worktree, capsys):
+        with patch.object(augment_tests, "call_claude_for_file", return_value=(NEW_TESTS, "")):
+            augment_tests_for_coverage(_state(worktree, issue_number=4))
+
+        assert "[N4c] appending to test_collector.py (#2908)" in capsys.readouterr().out


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-131639` (2026-09-06 13:16), resuming from run 39's grave. Run 39's N4c had added thirteen tests and taken coverage from 91 % to 99 %; its final measurement was `48 passed, 3 failed` of 51. Run 40's first measurement on the same tree:

```
[N2.5] Validating generated tests (mechanical)...
    Validation PASSED: 13 real tests
[N3] Results: 13 passed, 0 failed
[N5] Results: 35 passed, 3 failed | Coverage: 90.0%
```

The grave holds the thirteen: `pytest --collect-only` on its tip collects 26 tests from `tests/test_issue_4.py`, the spec's thirteen and N4c's thirteen. `augment_tests_for_coverage` writes to `Path(test_files[0])`, and `test_files[0]` is the spec suite. On resume the scaffold stage re-emits the suite from the spec (#2709 keeps it as the contract), and the file N4c appended to is replaced by its thirteen-test original. Two minutes of generation and eight points of coverage, gone on every resume.

## The change

`coverage_target_file(test_files, repo_root, issue_number)` returns the first entry of `test_files` that is not `tests/test_issue_<N>.py`. Only when the suite is the only file, or the issue number is unknown, does the first file stand as before. A plan-owned file survives a resume (#2897 registers it) and #2905 keeps its passing tests as written. N4c prints `[N4c] appending to <file> (#2908)`.

## Tests

Six cases added to `tests/unit/test_n4c_keeps_the_suite_and_bounds_output.py`:

- run 40's shape: the additions land in `tests/unit/test_collector.py`, the suite is untouched, the returned list is the given list;
- the addition survives the scaffold re-emitting the suite;
- with only the suite in the list, the suite is extended;
- the suite is skipped wherever it sits in the list;
- without an issue number the first file stands;
- N4c says which file.

The existing N4c cases pass unchanged (their state carries no issue number). `ruff` clean; the fail-open audit passes.

**Before:** on the unfixed tree the first case fails — the addition is in the suite and `test_collector.py` is untouched.

Closes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
