### PR TITLE
fix: the spec suite governs a test name both files carry, so a plan file copy that drifted from the spec is the implementer to change, not a contract to defend (Closes #2910)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
@@ -148,3 +148,31 @@ def keep_passing_tests_as_written(before: str, after: str, passing: set[str]) ->
     if after.endswith("\n"):
         source = source.rstrip("\n") + "\n"
     return Kept(source, restored, returned)
+
+
+def release_spec_twins(
+    contract: set[str], spec_suite_source: str | None,
+) -> tuple[set[str], set[str]]:
+    """The contract without the names the spec suite defines, and those names (#2910).
+
+    A plan-owned test file's `test_req_N` tests are copies of the spec's
+    requirements: the LLD plans a unit file per module and the spec suite is
+    generated from the same spec, which is the contract (#2709). On
+    run-issue4-131639 the plan file's copy of `test_req_13` asserted
+    `OSError` (run 39's rewrite) while the spec's asserted
+    `NotImplementedError`; the copy passed first, #2905 held it while N4
+    chased the spec's, and the loop ended at the cap raising neither. For a
+    name both files carry, the spec's copy governs and the plan file's is
+    the implementer's to change.
+    """
+    if not contract or not spec_suite_source:
+        return set(contract), set()
+    try:
+        tree = ast.parse(spec_suite_source)
+    except SyntaxError:
+        # fail-open: a spec suite that does not parse is the scaffold gate's
+        # finding; nothing is released and the #2905 keep stands as before.
+        return set(contract), set()
+    twins = {node.name for node, _ in _test_functions(tree).values()}
+    released = set(contract) & twins
+    return set(contract) - released, released

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -45,7 +45,11 @@ from .claude_client import (
     call_claude_for_file,
 )
 from .context import estimate_context_tokens
-from .keep_passing_tests import keep_passing_tests_as_written, passing_test_names
+from .keep_passing_tests import (
+    keep_passing_tests_as_written,
+    passing_test_names,
+    release_spec_twins,
+)
 from .parsers import (
     detect_summary_response,
     extract_code_block,
@@ -1090,6 +1094,26 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             contract = set(state.get("contract_tests") or []) or passing_test_names(
                 green_phase_output
             )
+            # #2910: the spec suite governs a name both files carry. On
+            # run-issue4-131639 the plan file's copy of test_req_13 asserted
+            # OSError against the spec's NotImplementedError; held as the
+            # contract, the copy walled the loop at the cap raising neither.
+            spec_suite = repo_root / "tests" / f"test_issue_{state.get('issue_number', 0)}.py"
+            if spec_suite.is_file() and target_path.resolve() != spec_suite.resolve():
+                try:
+                    spec_source = spec_suite.read_text(encoding="utf-8")
+                except OSError:
+                    # fail-open: an unreadable spec suite releases nothing and
+                    # the #2905 keep stands as before; the suite's own gate
+                    # reports a suite that cannot be read.
+                    spec_source = ""
+                contract, released = release_spec_twins(contract, spec_source)
+                if released:
+                    print(
+                        f"        [N4] {len(released)} test(s) also in the spec suite "
+                        f"are the spec's to define; this file's copy is free to "
+                        f"change: {', '.join(sorted(released))} (#2910)"
+                    )
             kept = keep_passing_tests_as_written(prior_text, code, contract)
             if kept.restored or kept.returned:
                 code = kept.source

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 304,
-    "sites_examined": 9219,
-    "findings_total": 553
+    "sites_examined": 9227,
+    "findings_total": 555
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_n4_keeps_passing_tests.py
+++ b/tests/unit/test_n4_keeps_passing_tests.py
@@ -348,3 +348,87 @@ def test_the_implementer_keeps_passing_tests_before_it_writes():
     write = source.index("# Write file (atomic: write to temp, then rename)")
     assert guard < write
     assert "(#2905)" in source
+
+
+SPEC_SUITE = '''\
+"""Spec suite for #4."""
+import pytest
+
+from boostgauge.collector import make_collector
+
+
+def test_req_13_mac_linux_raises_notimplemented(monkeypatch):
+    # Mac/Linux (REQ-13)
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(NotImplementedError):
+        make_collector()
+'''
+
+
+class TestTheSpecSuiteGovernsASharedName:
+    """#2910: run 40's plan-file copy of test_req_13 asserted OSError against
+    the spec's NotImplementedError; held as the contract it walled the loop."""
+
+    def test_run_40s_twin_is_released_and_the_rest_are_kept(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            release_spec_twins,
+        )
+
+        contract, released = release_spec_twins(PASSING, SPEC_SUITE)
+
+        assert released == {"test_req_13_mac_linux_raises_notimplemented"}
+        assert contract == {
+            "test_req_9_buffer_growth_on_mismatch", "test_req_10_oserror_fallback",
+        }
+
+    def test_the_released_copy_is_the_patchs_to_change(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            release_spec_twins,
+        )
+        contract, _ = release_spec_twins(PASSING, SPEC_SUITE)
+
+        kept = keep_passing_tests_as_written(RUN_32, RUN_39, contract)
+
+        assert sorted(kept.restored) == [
+            "test_req_10_oserror_fallback", "test_req_9_buffer_growth_on_mismatch",
+        ]
+        body = _function_text(kept.source, "test_req_13_mac_linux_raises_notimplemented")
+        assert "pytest.raises(OSError)" in body
+
+    def test_no_spec_suite_releases_nothing(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            release_spec_twins,
+        )
+
+        assert release_spec_twins(PASSING, None) == (PASSING, set())
+        assert release_spec_twins(PASSING, "") == (PASSING, set())
+        assert release_spec_twins(set(), SPEC_SUITE) == (set(), set())
+
+    def test_an_unparseable_spec_suite_releases_nothing(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            release_spec_twins,
+        )
+
+        assert release_spec_twins(PASSING, "def broken(:\n") == (PASSING, set())
+
+    def test_a_method_in_the_spec_suite_counts(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            release_spec_twins,
+        )
+        suite = "class TestReq:\n    def test_req_9_buffer_growth_on_mismatch(self):\n        assert 1\n"
+
+        _, released = release_spec_twins(PASSING, suite)
+
+        assert released == {"test_req_9_buffer_growth_on_mismatch"}
+
+    def test_the_implementer_releases_before_it_keeps(self):
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "testing" / "nodes" / "implementation"
+            / "orchestrator.py"
+        ).read_text(encoding="utf-8")
+
+        release = source.index("release_spec_twins(contract, spec_source)")
+        keep = source.index("keep_passing_tests_as_written(prior_text, code, contract)")
+        assert release < keep
+        assert "(#2910)" in source


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-131639` (2026-09-06 13:16), the first roll with #2905. The loop climbed 35 → 37 of 38 and ended at the cap with two failures:

```
[N4] kept 3 passing test(s) as written in tests/unit/test_collector.py: test_req_10_oserror_fallback, test_req_13_mac_linux_raises_notimplemented, test_req_9_buffer_growth_on_mismatch (#2905)
[N5] Results: 37 passed, 1 failed | Coverage: 91.0%
[N5] Results: 37 passed, 1 failed | Coverage: 91.0%
[N4] kept 1 passing test(s) as written in tests/unit/test_collector.py: test_req_13_mac_linux_raises_notimplemented (#2905)
[N5] Results: 36 passed, 2 failed | Coverage: 91.0%
[ERROR] Max iterations (5) reached with 2 failures
```

The two are one name in two files. The spec suite's `test_req_13_mac_linux_raises_notimplemented` asserts `NotImplementedError`, as the LLD says; the plan file's copy asserts `OSError`, run 39's rewrite. No `make_collector` satisfies both. The copy passed first, #2905 held it as the contract while N4 chased the spec's, and the implementation ended raising neither (`DID NOT RAISE` on both, on `graveyard/issue-4-20260906T183547Z`).

The plan file's `test_req_N` tests are copies of the spec's requirements by construction: the LLD plans a unit file per module and the spec suite is generated from the same spec, which is the contract (#2709). A copy that drifts from its twin is a contradiction the loop cannot resolve, and #2905 turned it into a wall.

## The change

- `keep_passing_tests.release_spec_twins(contract, spec_suite_source)` returns the contract without the names the spec suite defines, and the names it released. A suite that does not parse releases nothing (the scaffold gate's finding, with a ruling).
- `orchestrator.implement_code`: before keeping a plan-owned test file's passing tests, reads `tests/test_issue_<N>.py` (never for the suite itself) and releases the twins, printing `[N4] N test(s) also in the spec suite are the spec's to define; this file's copy is free to change: …`.

## Tests

Six cases added to `tests/unit/test_n4_keeps_passing_tests.py`:

- run 40's twin is released and the other two are kept; the released copy keeps the patch's text while req_9 and req_10 are restored;
- no spec suite, an empty one, or an empty contract release nothing; an unparseable suite releases nothing;
- a method in the spec suite counts;
- structural: the release runs before the keep.

`test_hill_climb.py`, the import-cycle guard, the node-supply allowlist and the halt-site ratchet pass unchanged. `ruff` clean; the fail-open audit passes with the two ruled sites.

**Before:** on the unfixed tree the plan file's `test_req_13` is kept as written with `OSError`, exactly as run 40's log shows.

Closes #2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
