### PR TITLE
fix: the verifier writes the spec suite text into a plan file copy of each spec test before it measures, so a drifted copy is never reported to the implementer (Closes #2912)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/keep_passing_tests.py
@@ -176,3 +176,94 @@ def release_spec_twins(
     twins = {node.name for node, _ in _test_functions(tree).values()}
     released = set(contract) & twins
     return set(contract) - released, released
+
+
+class Aligned(NamedTuple):
+    source: str
+    #: Tests whose text was replaced with the spec suite's copy.
+    aligned: list[str]
+    #: Import statements copied from the spec suite so those copies resolve.
+    imports_added: list[str]
+
+
+def align_spec_twins(plan_source: str, spec_source: str) -> Aligned:
+    """`plan_source` with every module-level test the spec suite also defines
+    carrying the spec's text (#2912).
+
+    #2910 released a plan file's twin to the implementer; on run-issue4-135112
+    the implementer still read the twin's failure -- `DID NOT RAISE OSError`
+    -- as the implementation's fault and rewrote `make_collector` to raise
+    `OSError`, which failed the spec's copy, which the hill-climb restored,
+    twice. The twin is a copy of the spec's test by construction, so the
+    honest state is the spec's text, and the verifier writes that state
+    before it measures: a drifted copy is never measured, never reported,
+    never chased.
+
+    Module-level functions only: a method's indentation is not a function's,
+    and the plan's `test_req_N` copies are module-level as the spec's are.
+    Import statements the spec suite has and the plan file lacks (verbatim)
+    are copied in after the plan file's imports, so a copied body resolves
+    the names its own file resolved. Either side failing to parse aligns
+    nothing: that is the syntax gate's finding.
+    """
+    if not spec_source or plan_source == spec_source:
+        return Aligned(plan_source, [], [])
+    try:
+        plan_tree = ast.parse(plan_source)
+        spec_tree = ast.parse(spec_source)
+    except SyntaxError:
+        # fail-open: an unparseable side is the syntax gate's finding; the
+        # plan file is left exactly as it is and measured as it is.
+        return Aligned(plan_source, [], [])
+
+    plan_lines = plan_source.splitlines()
+    spec_lines = spec_source.splitlines()
+    spec_tests = {
+        node.name: node for node, owner in _test_functions(spec_tree).values()
+        if owner is None
+    }
+
+    edits: list[tuple[int, int, list[str]]] = []
+    aligned: list[str] = []
+    for node, owner in _test_functions(plan_tree).values():
+        if owner is not None or node.name not in spec_tests:
+            continue
+        spec_text = _text(spec_lines, _span(spec_tests[node.name]))
+        span = _span(node)
+        if _text(plan_lines, span) != spec_text:
+            edits.append((span[0] - 1, span[1], spec_text.splitlines()))
+            aligned.append(node.name)
+    if not aligned:
+        return Aligned(plan_source, [], [])
+
+    plan_imports = [
+        node for node in plan_tree.body if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    present = set(plan_lines)
+    imports_added = [
+        _text(spec_lines, _span(node))
+        for node in spec_tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        and _text(spec_lines, _span(node)) not in present
+    ]
+    if imports_added:
+        if plan_imports:
+            at = max(node.end_lineno or node.lineno for node in plan_imports)
+        elif (
+            plan_tree.body
+            and isinstance(plan_tree.body[0], ast.Expr)
+            and isinstance(getattr(plan_tree.body[0], "value", None), ast.Constant)
+            and isinstance(plan_tree.body[0].value.value, str)
+        ):
+            at = plan_tree.body[0].end_lineno or plan_tree.body[0].lineno
+        else:
+            at = 0
+        edits.append((at, at, imports_added))
+
+    out = list(plan_lines)
+    for start, end, lines in sorted(edits, key=lambda e: e[0], reverse=True):
+        out[start:end] = lines
+    source = "\n".join(out)
+    if plan_source.endswith("\n"):
+        source = source.rstrip("\n") + "\n"
+    return Aligned(source, aligned, imports_added)

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -30,6 +30,7 @@ from assemblyzero.workflows.testing.checkpoints import record_measurement
 from assemblyzero.workflows.testing.circuit_breaker import check_circuit_breaker
 from assemblyzero.workflows.testing.nodes.e2e_validation import _extract_failed_test_names
 from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+    align_spec_twins,
     passing_test_names,
 )
 # `route_by_exit_code` is deliberately NOT imported here (#2671). It was, and
@@ -2033,6 +2034,61 @@ def _coverage_stagnant_message(
     )
 
 
+def _align_plan_files_with_the_spec(
+    state: TestingWorkflowState, repo_root: Path, test_files: list[str],
+) -> list[str]:
+    """Every plan-owned test file's twins carry the spec suite's text (#2912).
+
+    run-issue4-135112: #2910 had released the plan file's `test_req_13` to
+    the implementer, and the implementer read its failure -- `DID NOT RAISE
+    OSError` -- as the implementation's fault, rewrote `make_collector` to
+    raise `OSError`, failed the spec's copy, and was restored; twice. The
+    copy is the spec's test by construction; the verifier makes it so before
+    it measures, and reports what it aligned. Returns the relative paths it
+    rewrote.
+    """
+    spec_suite = repo_root / "tests" / f"test_issue_{state.get('issue_number', 0)}.py"
+    if not spec_suite.is_file():
+        return []
+    try:
+        spec_source = spec_suite.read_text(encoding="utf-8")
+    except OSError:
+        # fail-open: a spec suite that cannot be read aligns nothing; the
+        # run measures the plan files as they are, and the suite's own
+        # collection reports a suite that cannot be read.
+        return []
+    rewritten: list[str] = []
+    for file_str in test_files or []:
+        path = Path(file_str)
+        if not path.is_file() or path.resolve() == spec_suite.resolve():
+            continue
+        try:
+            plan_source = path.read_text(encoding="utf-8")
+        except OSError:
+            # fail-open: an unreadable plan file is measured as it is; the
+            # collection reports it if it cannot be read there either.
+            continue
+        aligned = align_spec_twins(plan_source, spec_source)
+        if not aligned.aligned:
+            continue
+        try:
+            path.write_text(aligned.source, encoding="utf-8")
+        except OSError as exc:
+            # fail-open: a file that cannot be written is measured as it
+            # was; said aloud so the drift it leaves is explained.
+            print(f"    [N5] could not align {path.name}: {exc}")
+            continue
+        rel = str(path.relative_to(repo_root)).replace("\\", "/") if path.is_relative_to(repo_root) else str(path)
+        print(
+            f"    [N5] aligned {len(aligned.aligned)} test(s) in {rel} with the spec "
+            f"suite's copies: {', '.join(aligned.aligned)} (#2912)"
+        )
+        if aligned.imports_added:
+            print(f"    [N5] copied {len(aligned.imports_added)} import(s) from the spec suite into {rel}")
+        rewritten.append(rel)
+    return rewritten
+
+
 def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     """N5: Verify all tests pass with coverage target.
 
@@ -2065,6 +2121,10 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     repo_root_str = state.get("repo_root", "")
     repo_root = Path(repo_root_str) if repo_root_str else get_repo_root()
     iteration_count = state.get("iteration_count", 0)
+
+    # #2912: a plan file's copy of a spec test carries the spec's text before
+    # anything is measured, so a drifted copy is never reported to N4.
+    _align_plan_files_with_the_spec(state, repo_root, test_files)
 
     print(f"    Running pytest with coverage target: {coverage_target}%")
 

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 304,
-    "sites_examined": 9232,
-    "findings_total": 555
+    "sites_examined": 9255,
+    "findings_total": 559
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_n4_keeps_passing_tests.py
+++ b/tests/unit/test_n4_keeps_passing_tests.py
@@ -432,3 +432,148 @@ class TestTheSpecSuiteGovernsASharedName:
         keep = source.index("keep_passing_tests_as_written(prior_text, code, contract)")
         assert release < keep
         assert "(#2910)" in source
+
+
+# The spec suite as run 41's scaffold emitted it, reduced to the twin and
+# an import the plan file lacks.
+RUN_41_SPEC_SUITE = '''\
+"""Spec suite for #4."""
+import pytest
+
+from boostgauge.collector import make_collector
+from boostgauge.thresholds import Thresholds
+
+
+def test_req_13_mac_linux_raises_notimplemented(monkeypatch):
+    # Mac/Linux (REQ-13)
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(NotImplementedError):
+        make_collector()
+
+
+def test_req_14_thresholds_default():
+    assert Thresholds()
+'''
+
+
+class TestTheVerifierAlignsTwins:
+    """#2912: before a measurement, a plan file's copy of a spec test carries
+    the spec's text. run-issue4-135112's implementer read the drifted copy's
+    `DID NOT RAISE OSError` as the implementation's fault, twice."""
+
+    def test_run_41s_twin_takes_the_specs_text(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+
+        aligned = align_spec_twins(RUN_39, RUN_41_SPEC_SUITE)
+
+        assert aligned.aligned == ["test_req_13_mac_linux_raises_notimplemented"]
+        body = _function_text(aligned.source, "test_req_13_mac_linux_raises_notimplemented")
+        assert body == _function_text(RUN_41_SPEC_SUITE, "test_req_13_mac_linux_raises_notimplemented")
+        assert "pytest.raises(OSError)" not in body
+
+    def test_the_other_tests_are_untouched(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+
+        aligned = align_spec_twins(RUN_39, RUN_41_SPEC_SUITE)
+
+        for name in (
+            "test_req_9_buffer_growth_on_mismatch", "test_req_10_oserror_fallback",
+            "test_collect_with_thresholds_computes_composite",
+        ):
+            assert _function_text(aligned.source, name) == _function_text(RUN_39, name)
+        assert "def test_req_14_thresholds_default" not in aligned.source
+
+    def test_the_imports_the_copy_needs_are_carried_over(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+
+        aligned = align_spec_twins(RUN_39, RUN_41_SPEC_SUITE)
+
+        assert aligned.imports_added == ["from boostgauge.thresholds import Thresholds"]
+        tree = ast.parse(aligned.source)
+        imports = [n for n in tree.body if isinstance(n, (ast.Import, ast.ImportFrom))]
+        assert imports[-1].lineno < next(
+            n.lineno for n in tree.body if isinstance(n, ast.FunctionDef)
+        )
+        assert aligned.source.count("import pytest") == 1
+
+    def test_an_aligned_file_is_a_fixed_point(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+        once = align_spec_twins(RUN_39, RUN_41_SPEC_SUITE)
+
+        again = align_spec_twins(once.source, RUN_41_SPEC_SUITE)
+
+        assert again == (once.source, [], [])
+
+    def test_a_copy_already_matching_aligns_nothing(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+        spec = _function_text(RUN_32, "test_req_13_mac_linux_raises_notimplemented")
+
+        assert align_spec_twins(RUN_32, spec + "\n") == (RUN_32, [], [])
+
+    def test_a_method_is_never_aligned_with_a_function(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+        plan = "class TestReq:\n    def test_req_13_mac_linux_raises_notimplemented(self):\n        assert 1\n"
+
+        assert align_spec_twins(plan, RUN_41_SPEC_SUITE) == (plan, [], [])
+
+    def test_an_unparseable_side_aligns_nothing(self):
+        from assemblyzero.workflows.testing.nodes.implementation.keep_passing_tests import (
+            align_spec_twins,
+        )
+
+        assert align_spec_twins(RUN_39, "def broken(:\n") == (RUN_39, [], [])
+        assert align_spec_twins("def broken(:\n", RUN_41_SPEC_SUITE) == ("def broken(:\n", [], [])
+
+    def test_the_verifier_rewrites_the_plan_file_and_says_so(self, tmp_path, capsys):
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _align_plan_files_with_the_spec,
+        )
+        (tmp_path / "tests" / "unit").mkdir(parents=True)
+        suite = tmp_path / "tests" / "test_issue_4.py"
+        plan = tmp_path / "tests" / "unit" / "test_collector.py"
+        suite.write_text(RUN_41_SPEC_SUITE, encoding="utf-8")
+        plan.write_text(RUN_39, encoding="utf-8")
+
+        rewritten = _align_plan_files_with_the_spec(
+            {"issue_number": 4}, tmp_path, [str(suite), str(plan)],
+        )
+
+        assert rewritten == ["tests/unit/test_collector.py"]
+        assert "pytest.raises(NotImplementedError)" in plan.read_text(encoding="utf-8")
+        assert suite.read_text(encoding="utf-8") == RUN_41_SPEC_SUITE
+        out = capsys.readouterr().out
+        assert "[N5] aligned 1 test(s) in tests/unit/test_collector.py" in out
+        assert "test_req_13_mac_linux_raises_notimplemented (#2912)" in out
+
+    def test_without_a_spec_suite_nothing_is_touched(self, tmp_path):
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _align_plan_files_with_the_spec,
+        )
+        (tmp_path / "tests" / "unit").mkdir(parents=True)
+        plan = tmp_path / "tests" / "unit" / "test_collector.py"
+        plan.write_text(RUN_39, encoding="utf-8")
+
+        assert _align_plan_files_with_the_spec({"issue_number": 4}, tmp_path, [str(plan)]) == []
+        assert plan.read_text(encoding="utf-8") == RUN_39
+
+    def test_the_verifier_aligns_before_it_measures(self):
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "testing" / "nodes" / "verify_phases.py"
+        ).read_text(encoding="utf-8")
+        node = source.index("def verify_green_phase(")
+        align = source.index("_align_plan_files_with_the_spec(state, repo_root, test_files)", node)
+        measure = source.index("Running pytest with coverage target", node)
+        assert align < measure


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-135112` (2026-09-06 13:51), the first roll with #2910. Resumed at the best measured checkpoint, 37 of 38, the one failure the plan file's `test_req_13` copy (`DID NOT RAISE OSError`, run 39's rewrite) against a `make_collector` that raises `NotImplementedError` as the spec's copy demands:

```
[N4] 13 test(s) also in the spec suite are the spec's to define; this file's copy is free to change: test_req_10_oserror_fallback, …
[EDIT-SCRIPT] Applied 1 edit(s); 99% of the prior file preserved byte-identical      (collector.py)
[EDIT-SCRIPT] Applied 1 edit(s); 100% of the prior file preserved byte-identical     (test_collector.py)
[N5] Results: 36 passed, 2 failed | Coverage: 91.0%
[N5] iteration regressed (36 passing at 91.0% vs best 37 at 91.0%) — restored 6 file(s)
```

#2910 released the copy, but "free to change" reached the log, not the model. The implementer's per-file call sees the failure corpus and reads `DID NOT RAISE <class 'OSError'>` as the implementation's fault: it rewrote `make_collector` to raise `OSError`, which failed the spec's copy, and the hill-climb restored. The test file's call applied an edit that changed nothing. The next iteration repeated it.

The copy is the spec's test by construction (#2910). Telling the model so in prose is one more instruction to weigh against a traceback; writing the spec's text into the copy is a fact.

## The change

- `keep_passing_tests.align_spec_twins(plan_source, spec_source)`: every module-level test the spec suite also defines carries the spec's text, decorators included; import statements the spec suite has and the plan file lacks (verbatim) are copied in after the plan file's imports so a copied body resolves. Methods are never aligned with functions. Either side failing to parse aligns nothing (ruled).
- `verify_phases._align_plan_files_with_the_spec(state, repo_root, test_files)` runs it on every plan-owned test file — never the suite itself — at the top of `verify_green_phase`, before pytest, and prints `[N5] aligned N test(s) in <file> with the spec suite's copies: …`.

## Tests

Ten cases added to `tests/unit/test_n4_keeps_passing_tests.py`, on run 41's files:

- the twin takes the spec's text and `OSError` is gone; the other tests are untouched and the spec's other tests are not copied in;
- the import the copy needs is carried over, once, before the first test;
- an aligned file is a fixed point; a copy that already matches aligns nothing; a method is never aligned with a function; an unparseable side aligns nothing;
- the verifier rewrites the plan file, leaves the suite, and says so; without a suite nothing is touched;
- structural: the verifier aligns before it measures.

`test_hill_climb.py`, the import-cycle guard, the node-supply allowlist and the halt-site ratchet pass unchanged. `ruff` clean; the fail-open audit passes with the ruled sites.

**Before:** on the unfixed tree the plan file's copy is measured as written — `DID NOT RAISE OSError` — and handed to the implementer, exactly as run 41's log shows.

Closes #2912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
