### PR TITLE
fix: the full-suite check hands N4 a collection error cause, and a file with nothing to fix can say NO-EDIT instead of being regenerated (Closes #2914, Closes #2915)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
@@ -113,17 +113,22 @@ class EditScriptOutcome:
         blocks: int = 0,
         preserved: float = 0.0,
         failures: list[str] | None = None,
+        no_edit: str | None = None,
     ) -> None:
         self.code = code
         self.blocks = blocks
         self.preserved = preserved
         self.failures = failures or []
+        #: #2915: the model's stated reason that this file needs no change.
+        self.no_edit = no_edit
 
     @property
     def ok(self) -> bool:
         return self.code is not None
 
     def describe(self) -> str:
+        if self.no_edit is not None:
+            return f"[EDIT-SCRIPT] no edits; the model says: {self.no_edit} (#2915)"
         if self.ok:
             return (
                 f"[EDIT-SCRIPT] Applied {self.blocks} edit(s); "
@@ -423,7 +428,11 @@ def build_code_edit_script_prompt(
         "name in a SEARCH block cannot and must not change, and the passing "
         "tests depend on that.\n"
         "4. No preamble, no explanation, no markdown fences around the "
-        "blocks -- edit blocks only."
+        "blocks -- edit blocks only.\n"
+        "5. If nothing in THIS file needs to change for the failures listed "
+        "-- the fix belongs in another file -- output exactly one line and "
+        "nothing else: NO-EDIT: <why>. Never rewrite a file to have "
+        "something to say."
     ]
 
     if failure_context:
@@ -445,6 +454,25 @@ def build_code_edit_script_prompt(
     return "\n\n".join(sections)
 
 
+_NO_EDIT_RE = re.compile(r"^\s*NO-EDIT\s*:?\s*(?P<reason>.*)$", re.IGNORECASE)
+
+
+def _no_edit_reason(response: str) -> str | None:
+    """The reason given on a `NO-EDIT: <why>` answer, or None (#2915).
+
+    Only a response that IS the declaration counts -- one line, optionally
+    fenced -- so a stray mention inside an edit block never silences a patch.
+    """
+    lines = [line for line in response.strip().splitlines() if line.strip()]
+    lines = [line for line in lines if not line.strip().startswith("```")]
+    if len(lines) != 1:
+        return None
+    match = _NO_EDIT_RE.match(lines[0])
+    if match is None:
+        return None
+    return match.group("reason").strip() or "no reason given"
+
+
 def apply_code_edit_script(
     response: str, existing_content: str
 ) -> EditScriptOutcome:
@@ -455,6 +483,15 @@ def apply_code_edit_script(
     at all, so it cannot be quietly rewritten. That is the property #1528 was
     built for and the one this issue asks the implementation stage to inherit.
     """
+    declined = _no_edit_reason(response or "")
+    if declined is not None:
+        # #2915: a file the failures name but that has nothing to fix -- on
+        # run-issue4-135112 windows.py was named by a circular import whose
+        # fix was in collector.py -- answered with no blocks, and the caller
+        # regenerated it whole. "Nothing to change here" is an answer, and
+        # the file it is about stays exactly as it is.
+        return EditScriptOutcome(existing_content, preserved=1.0, no_edit=declined)
+
     blocks = parse_edit_blocks(response or "")
     if not blocks:
         return EditScriptOutcome(None, failures=["no edit blocks in response"])

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -249,6 +249,84 @@ def _build_failure_summary(output: str) -> str:
 _TRACEBACK_FRAME = re.compile(r"^\S+?\.py:\d+: in \S+")
 
 
+_FRAME_LINE_RE = re.compile(r"^(?P<path>[^\s:]+\.py):(?P<line>\d+): in (?P<where>\S+)\s*$")
+_CIRCULAR_MARKERS = ("partially initialized module", "circular import")
+
+
+def collection_error_blocks(output: str) -> str:
+    """The cause of each collection error in pytest's ERRORS section, as blocks
+    the implementer can attribute (#2914).
+
+    run-issue4-135112: the first green pass of boostgauge #4, and the full-suite
+    check found `Interrupted: 2 errors during collection`. What N4 was handed
+    was the short summary's `ERROR tests/integration/...` -- a file name and
+    nothing under it -- so attribution matched the test files and windows.py
+    (the importer), and the file that closes the cycle, collector.py:114,
+    was left alone. The ERRORS section had the whole chain.
+
+    Each distinct error becomes one block: the frames from the first source
+    frame onward (the importing test file's own frame is omitted, since the
+    fix is never there), the `E` lines, and for a circular import a sentence
+    naming the innermost source frame as the import to move. One block per
+    distinct error line, however many test files tripped over it.
+    """
+    match = re.search(
+        r"^=+ ERRORS =+$(?P<body>.*?)(?=^=+ (?:short test summary|warnings summary|"
+        r"FAILURES|[\w ]*coverage)|\Z)",
+        output or "", re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return ""
+    blocks: list[str] = []
+    seen: set[str] = set()
+    for section in re.split(r"^_+ ERROR collecting \S+ _+$", match.group("body"), flags=re.MULTILINE)[1:]:
+        lines = section.splitlines()
+        frames: list[str] = []
+        errors: list[str] = []
+        innermost: tuple[str, str] | None = None
+        i = 0
+        while i < len(lines):
+            frame = _FRAME_LINE_RE.match(lines[i].strip())
+            if frame:
+                path = frame.group("path").replace("\\", "/")
+                is_test = path.startswith("tests/") or path.startswith("test/") or "/tests/" in path
+                if not is_test:
+                    frames.append(lines[i].rstrip())
+                    if i + 1 < len(lines) and not _FRAME_LINE_RE.match(lines[i + 1].strip()) and not lines[i + 1].startswith("E "):
+                        frames.append(lines[i + 1].rstrip())
+                    innermost = (path, frame.group("line"))
+                i += 1
+                continue
+            if lines[i].startswith("E "):
+                errors.append(lines[i].rstrip())
+            i += 1
+        if not errors:
+            continue
+        key = "\n".join(errors)
+        if key in seen:
+            continue
+        seen.add(key)
+        circular = any(marker in key for marker in _CIRCULAR_MARKERS)
+        if circular and innermost:
+            heading = (
+                f"Collection failed with a circular import (#2914): "
+                f"{innermost[0]}:{innermost[1]} imports at module level from a "
+                f"module that imports this file back at module level, so "
+                f"whichever loads first, the other fails. Move the import at "
+                f"{innermost[0]}:{innermost[1]} inside the function that uses it. "
+                f"Only that file changes; the test files are the contract."
+            )
+        elif innermost:
+            heading = (
+                f"Collection failed (#2914): the test suite could not be imported; "
+                f"the failing import is at {innermost[0]}:{innermost[1]}."
+            )
+        else:
+            heading = "Collection failed (#2914): the test suite could not be imported."
+        blocks.append("\n".join([heading, *frames, *errors]))
+    return "\n\n".join(blocks)
+
+
 def _extract_traceback_blocks(output: str) -> str:
     """Pull distinct failure tracebacks out of pytest's FAILURES section.
 
@@ -2919,6 +2997,16 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             full_output = full_result["stdout"] + "\n" + full_result["stderr"]
             regression_summary = _build_failure_summary(full_output)
             regression_names = _extract_failed_test_names(full_output)
+            # #2914: a collection error's cause leads the summary, so
+            # attribution reaches the file that owns it rather than the test
+            # files that tripped over it.
+            collection_cause = collection_error_blocks(full_output)
+            if collection_cause:
+                regression_summary = (collection_cause + "\n\n" + regression_summary).strip()
+                print(
+                    f"    [N5] Full suite: collection failed ({full_errors} error(s)); "
+                    f"nothing ran -- routing the cause to N4 (#2914)"
+                )
 
             # Check for stagnation: same regressions across 2 iterations → halt
             previous_regressions = state.get("full_suite_regressions", [])

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 304,
-    "sites_examined": 9255,
+    "sites_examined": 9276,
     "findings_total": 559
   },
   "undeclared": [

--- a/tests/unit/test_full_suite_carries_the_collection_cause.py
+++ b/tests/unit/test_full_suite_carries_the_collection_cause.py
@@ -1,0 +1,185 @@
+"""The full-suite check hands N4 a collection error's cause, and a file with
+nothing to fix can say so (#2914, #2915).
+
+boostgauge #4, `run-issue4-135112` (2026-09-06 13:51): the first green pass of
+the campaign, 47 tests at 97 %, and then the one full-suite check (#842):
+
+    [N5] Full suite: 2 regression(s) detected (0 passed) — routing back to N4
+    [N4] failures attributed to 3 of 5 file(s): src/boostgauge/collectors/windows.py,
+         tests/benchmark/test_sweep_cost.py, tests/integration/test_windows_sweep_crosscheck.py
+    [EDIT-SCRIPT] fell back to full regeneration: no edit blocks in response   (windows.py)
+
+N4 was handed `ERROR tests/integration/test_windows_sweep_crosscheck.py` and
+nothing under it. The ERRORS section, reproduced on the run's checkpoint,
+named the cause: a circular import closed by `src/boostgauge/collector.py:114`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    EditScriptOutcome,
+    apply_code_edit_script,
+    build_code_edit_script_prompt,
+    is_attributed,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import collection_error_blocks
+
+# `pytest --co -q` on graveyard/issue-4 at checkpoint 4ff3f98, verbatim but for
+# the machine path in the last E line.
+RUN_41_FULL_SUITE = """\
+=================================== ERRORS ====================================
+_____________ ERROR collecting tests/benchmark/test_sweep_cost.py _____________
+ImportError while importing test module 'C:\\Users\\mcwiz\\Projects\\boostgauge-run41\\tests\\benchmark\\test_sweep_cost.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+tests\\benchmark\\test_sweep_cost.py:7: in <module>
+    from boostgauge.collectors.windows import WindowsCollector
+src\\boostgauge\\collectors\\windows.py:13: in <module>
+    from boostgauge.collector import (
+src\\boostgauge\\collector.py:114: in <module>
+    from boostgauge.collectors.windows import WindowsCollector
+E   ImportError: cannot import name 'WindowsCollector' from partially initialized module 'boostgauge.collectors.windows' (most likely due to a circular import) (src/boostgauge/collectors/windows.py)
+_____ ERROR collecting tests/integration/test_windows_sweep_crosscheck.py _____
+ImportError while importing test module 'C:\\Users\\mcwiz\\Projects\\boostgauge-run41\\tests\\integration\\test_windows_sweep_crosscheck.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+tests\\integration\\test_windows_sweep_crosscheck.py:6: in <module>
+    from boostgauge.collectors.windows import CONSOLE_HOSTS, WindowsCollector
+src\\boostgauge\\collectors\\windows.py:13: in <module>
+    from boostgauge.collector import (
+src\\boostgauge\\collector.py:114: in <module>
+    from boostgauge.collectors.windows import WindowsCollector
+E   ImportError: cannot import name 'WindowsCollector' from partially initialized module 'boostgauge.collectors.windows' (most likely due to a circular import) (src/boostgauge/collectors/windows.py)
+=========================== short test summary info ===========================
+ERROR tests/benchmark/test_sweep_cost.py
+ERROR tests/integration/test_windows_sweep_crosscheck.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
+116 tests collected, 2 errors in 0.48s
+"""
+
+
+class TestRun41sCircularImport:
+    def test_the_cause_names_the_import_that_closes_the_cycle(self):
+        blocks = collection_error_blocks(RUN_41_FULL_SUITE)
+
+        assert "circular import" in blocks
+        assert "src/boostgauge/collector.py:114" in blocks
+        assert "Move the import at src/boostgauge/collector.py:114" in blocks
+        assert "E   ImportError: cannot import name 'WindowsCollector'" in blocks
+
+    def test_two_test_files_tripping_on_one_cause_is_one_block(self):
+        blocks = collection_error_blocks(RUN_41_FULL_SUITE)
+
+        assert blocks.count("Collection failed") == 1
+
+    def test_the_importing_test_files_are_not_in_the_block(self):
+        blocks = collection_error_blocks(RUN_41_FULL_SUITE)
+
+        assert "test_sweep_cost" not in blocks
+        assert "test_windows_sweep_crosscheck" not in blocks
+
+    def test_attribution_reaches_collector_and_not_the_test_files(self):
+        blocks = collection_error_blocks(RUN_41_FULL_SUITE)
+
+        assert is_attributed(blocks, "src/boostgauge/collector.py")
+        assert not is_attributed(blocks, "tests/benchmark/test_sweep_cost.py")
+        assert not is_attributed(blocks, "tests/integration/test_windows_sweep_crosscheck.py")
+
+    def test_the_source_frames_travel_with_their_lines(self):
+        blocks = collection_error_blocks(RUN_41_FULL_SUITE)
+
+        assert "src\\boostgauge\\collector.py:114: in <module>" in blocks
+        assert "    from boostgauge.collectors.windows import WindowsCollector" in blocks
+
+
+class TestOtherShapes:
+    def test_no_errors_section_is_empty(self):
+        assert collection_error_blocks("3 passed in 0.1s\n") == ""
+        assert collection_error_blocks("") == ""
+
+    def test_a_plain_import_error_names_the_failing_frame(self):
+        output = (
+            "=================================== ERRORS ====================================\n"
+            "_______________ ERROR collecting tests/unit/test_config.py ________________\n"
+            "Traceback:\n"
+            "tests\\unit\\test_config.py:3: in <module>\n"
+            "    from boostgauge.config import load\n"
+            "src\\boostgauge\\config.py:9: in <module>\n"
+            "    import tomllib_missing\n"
+            "E   ModuleNotFoundError: No module named 'tomllib_missing'\n"
+            "=========================== short test summary info ===========================\n"
+            "ERROR tests/unit/test_config.py\n"
+        )
+
+        blocks = collection_error_blocks(output)
+
+        assert "circular" not in blocks
+        assert "the failing import is at src/boostgauge/config.py:9" in blocks
+        assert "E   ModuleNotFoundError: No module named 'tomllib_missing'" in blocks
+        assert is_attributed(blocks, "src/boostgauge/config.py")
+
+    def test_the_full_suite_path_leads_with_the_cause(self):
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "testing" / "nodes" / "verify_phases.py"
+        ).read_text(encoding="utf-8")
+        start = source.index("full_result = run_pytest([], repo_root=repo_root)")
+        cause = source.index("collection_cause = collection_error_blocks(full_output)", start)
+        routed = source.index('"test_failure_summary": regression_summary', start)
+        assert cause < routed
+        assert "nothing ran -- routing the cause to N4 (#2914)" in source
+
+
+class TestAFileWithNothingToFixCanSaySo:
+    """#2915: run 41's windows.py was named by the circular import and had
+    nothing to change; its no-blocks answer regenerated it whole."""
+
+    EXISTING = "import ctypes\n\n\nclass WindowsCollector:\n    pass\n"
+
+    def test_a_no_edit_answer_keeps_the_file_byte_for_byte(self):
+        outcome = apply_code_edit_script(
+            "NO-EDIT: the circular import is closed in collector.py:114, not here",
+            self.EXISTING,
+        )
+
+        assert outcome.ok
+        assert outcome.code == self.EXISTING
+        assert outcome.no_edit == "the circular import is closed in collector.py:114, not here"
+        assert outcome.describe() == (
+            "[EDIT-SCRIPT] no edits; the model says: the circular import is "
+            "closed in collector.py:114, not here (#2915)"
+        )
+
+    def test_a_fenced_or_bare_declaration_counts(self):
+        for response in ("```\nNO-EDIT: nothing here\n```", "no-edit nothing here", "NO-EDIT:"):
+            outcome = apply_code_edit_script(response, self.EXISTING)
+            assert outcome.ok and outcome.code == self.EXISTING, response
+
+    def test_a_mention_inside_an_edit_block_is_not_a_declaration(self):
+        response = (
+            "<<<<<<< SEARCH\n    pass\n=======\n    # NO-EDIT: not really\n    pass\n>>>>>>> REPLACE\n"
+        )
+
+        outcome = apply_code_edit_script(response, self.EXISTING)
+
+        assert outcome.no_edit is None
+        assert outcome.blocks == 1
+
+    def test_an_empty_answer_still_falls_back(self):
+        outcome = apply_code_edit_script("", self.EXISTING)
+
+        assert not outcome.ok
+        assert outcome.no_edit is None
+        assert "no edit blocks in response" in outcome.describe()
+
+    def test_the_prompt_offers_the_answer(self):
+        prompt = build_code_edit_script_prompt("src/x.py", self.EXISTING, "FAILED t::test_a")
+
+        assert "NO-EDIT: <why>" in prompt
+        assert "Never rewrite a file to have something to say" in prompt
+
+    def test_the_outcome_type_carries_the_reason(self):
+        assert EditScriptOutcome("x", no_edit="why").no_edit == "why"
+        assert EditScriptOutcome("x").no_edit is None


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-135112` (2026-09-06 13:51). The first green pass of the campaign, 47 tests at 97 %, and then the one full-suite check (#842):

```
[N5] Full suite: 2 regression(s) detected (0 passed) — routing back to N4
[N4] failures attributed to 3 of 5 file(s): src/boostgauge/collectors/windows.py, tests/benchmark/test_sweep_cost.py, tests/integration/test_windows_sweep_crosscheck.py
[EDIT-SCRIPT] fell back to full regeneration: no edit blocks in response      (windows.py)
```

What N4 was handed, in full: `ERROR tests/integration/test_windows_sweep_crosscheck.py`. What the full suite said, reproduced on the run's checkpoint:

```
src\boostgauge\collectors\windows.py:13: in <module>
    from boostgauge.collector import (
src\boostgauge\collector.py:114: in <module>
    from boostgauge.collectors.windows import WindowsCollector
E   ImportError: cannot import name 'WindowsCollector' from partially initialized module 'boostgauge.collectors.windows' (most likely due to a circular import)
Interrupted: 2 errors during collection
```

A circular import that holds when `collector` loads first (the targeted run's order) and breaks when a test imports `windows` first (the full suite's alphabetical walk). The file to change is `collector.py:114`. The full-suite path built its summary from the short-summary section alone, so the traceback never reached N4; attribution matched the error's file names; and `windows.py`, with nothing to fix, answered with no blocks — which the protocol reads as a failed patch and, for an implementation file, regenerates from scratch.

## The change

- `verify_phases.collection_error_blocks(output)` reads the ERRORS section into one block per distinct cause: the source frames with their lines (the importing test file's own frame omitted — the fix is never there), the `E` lines, and for a circular import a sentence naming the innermost source frame as the import to move. The full-suite path leads its summary with it and prints `collection failed (N error(s)); nothing ran` instead of `0 passed`.
- `edit_script_fix`: rule 5 of the edit-script prompt allows exactly one line, `NO-EDIT: <why>`; `apply_code_edit_script` returns the file unchanged with the reason, reported as `[EDIT-SCRIPT] no edits; the model says: …`. Only a response that IS the declaration counts.

## Tests

`tests/unit/test_full_suite_carries_the_collection_cause.py`, fourteen cases on run 41's output:

- the cause names `src/boostgauge/collector.py:114` and the circular import; two test files tripping on one cause is one block; the importing test files are not in the block; attribution reaches `collector.py` and not the test files; the source frames travel with their lines;
- no ERRORS section is empty; a plain import error names the failing frame; the full-suite path leads with the cause (structural);
- a `NO-EDIT` answer keeps the file byte for byte and says so; fenced or bare forms count; a mention inside an edit block does not; an empty answer still falls back; the prompt offers the answer; the outcome carries the reason.

The green-collection (#2894), exit-code and import-cycle suites pass unchanged. `ruff` clean; the fail-open audit passes.

**Before:** on the unfixed tree the summary is the one line run 41 shows, `collector.py` is not attributed, and a `NO-EDIT` answer regenerates the file.

Closes #2914
Closes #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
