### PR TITLE
fix: the circular-import block states that the re-exported name must stay importable and names the lazy re-export that keeps it, instead of telling the implementer to move the import (Closes #2922)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -251,6 +251,12 @@ _TRACEBACK_FRAME = re.compile(r"^\S+?\.py:\d+: in \S+")
 
 _FRAME_LINE_RE = re.compile(r"^(?P<path>[^\s:]+\.py):(?P<line>\d+): in (?P<where>\S+)\s*$")
 _CIRCULAR_MARKERS = ("partially initialized module", "circular import")
+# #2922: the name and module of a circular-import error line, which reads
+# `cannot import name 'X' from partially initialized module 'M'`.
+_CIRCULAR_IMPORT_NAME_RE = re.compile(
+    r"cannot import name ['\"](?P<name>[\w.]+)['\"] from "
+    r"(?:partially initialized module )?['\"](?P<module>[\w.]+)['\"]"
+)
 
 
 def collection_error_blocks(output: str) -> str:
@@ -308,13 +314,25 @@ def collection_error_blocks(output: str) -> str:
         seen.add(key)
         circular = any(marker in key for marker in _CIRCULAR_MARKERS)
         if circular and innermost:
+            # #2922: the import at the innermost frame is, on the shape this
+            # was built for, a RE-EXPORT the tests depend on -- "move it
+            # inside a function" removed the name and the spec suite died.
+            # State the constraint and the one repair that satisfies it.
+            imported = _CIRCULAR_IMPORT_NAME_RE.search(key)
+            name = imported.group("name") if imported else "the name"
+            source_module = imported.group("module") if imported else "the other module"
             heading = (
-                f"Collection failed with a circular import (#2914): "
-                f"{innermost[0]}:{innermost[1]} imports at module level from a "
-                f"module that imports this file back at module level, so "
-                f"whichever loads first, the other fails. Move the import at "
-                f"{innermost[0]}:{innermost[1]} inside the function that uses it. "
-                f"Only that file changes; the test files are the contract."
+                f"Collection failed with a circular import (#2914, #2922): "
+                f"{innermost[0]}:{innermost[1]} imports `{name}` from "
+                f"{source_module} at module level, and {source_module} imports "
+                f"this file back at module level, so whichever loads first, "
+                f"the other fails. `{name}` must stay importable from this "
+                f"module -- tests import it from here -- so do NOT remove or "
+                f"move that import. Replace it with a lazy re-export: a "
+                f"module-level `def __getattr__(attr):` that imports `{name}` "
+                f"from {source_module} on first access and raises "
+                f"AttributeError for any other attr. Only {innermost[0]} "
+                f"changes; every other file named here answers NO-EDIT."
             )
         elif innermost:
             heading = (

--- a/tests/unit/test_full_suite_carries_the_collection_cause.py
+++ b/tests/unit/test_full_suite_carries_the_collection_cause.py
@@ -66,7 +66,14 @@ class TestRun41sCircularImport:
 
         assert "circular import" in blocks
         assert "src/boostgauge/collector.py:114" in blocks
-        assert "Move the import at src/boostgauge/collector.py:114" in blocks
+        # #2922: the name is a re-export the tests depend on; the block says
+        # so and names the one repair that keeps it.
+        assert "`WindowsCollector` must stay importable from this module" in blocks
+        assert "do NOT remove or move that import" in blocks
+        assert "def __getattr__(attr):" in blocks
+        assert "imports `WindowsCollector` from boostgauge.collectors.windows" in blocks
+        assert "Only src/boostgauge/collector.py changes; every other file named here answers NO-EDIT" in blocks
+        assert "inside the function that uses it" not in blocks
         assert "E   ImportError: cannot import name 'WindowsCollector'" in blocks
 
     def test_two_test_files_tripping_on_one_cause_is_one_block(self):


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-143856` (2026-09-06 14:38), the first run with #2914's cause, #2919's snapshot and #2920's repair pass all in place. Green at 50 tests, 97 %; the full-suite check named the circular import and `collector.py` was attributed. The implementer did what the block said:

```
<<<<<<< SEARCH
from boostgauge.collectors.windows import WindowsCollector


def make_collector(thresholds: Thresholds | None = None) -> DataCollector:
=======
def make_collector(thresholds: Thresholds | None = None) -> DataCollector:
>>>>>>> REPLACE
```

and the spec suite, which imports the name from there, died:

```
E   ImportError: cannot import name 'WindowsCollector' from 'boostgauge.collector'
[N5] Results: 0 passed, 1 failed | Coverage: 40.0%
```

The import at `collector.py:114` is a re-export: the spec suite and the plan's unit file do `from boostgauge.collector import WindowsCollector`, as LLD-004 §2.5 intends. "Move the import inside the function that uses it" removes the name. `windows.py`, attributed by its frame, answered with the `__bases__` reassignment it tried in run 42. The snapshot restored 50 at 97 % both times; the next pass gets the same block and does the same thing.

## The change

`collection_error_blocks` reads the imported name and module off the error line (`cannot import name 'X' from partially initialized module 'M'`) and the circular-import block now states the constraint and the one repair that satisfies it: `X` must stay importable from this module, so do not remove or move the import; replace it with a module-level `def __getattr__(attr):` that imports `X` from `M` on first access and raises `AttributeError` for anything else. Only the innermost file changes; every other file named answers `NO-EDIT` (#2915).

## Tests

`test_full_suite_carries_the_collection_cause.py`'s cause test asserts the new wording on run 41's output: the name must stay importable, the import is not to be removed or moved, the `__getattr__` shape is named with the right name and module, `collector.py` is the file that changes and the rest answer `NO-EDIT`, and the old sentence is gone. The other thirteen cases pass unchanged; `ruff` clean.

**Before:** the block says "Move the import at src/boostgauge/collector.py:114 inside the function that uses it", which run 43 followed to zero passing.

Closes #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
