### PR TITLE
fix: the runner pytest carries -vv, so an assertion compared values reach the implementer whole instead of pytest truncated repr (Closes #2924)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -740,7 +740,12 @@ def run_pytest(
         Dict with returncode, stdout, stderr, and parsed results.
     """
     # Issue #268: Use poetry run to ensure correct virtualenv with dependencies
-    cmd = ["poetry", "run", "pytest", "-v", "--tb=short"]
+    # #2924: -vv, not -v. At verbosity 1 pytest truncates the reprs in an
+    # assertion's comparison -- run-issue4-145211 handed N4
+    # `Thresholds(co...0, red=50000)) == Thresholds(co...0, red=20000))` for a
+    # regression whose only fix was the four elided bands, and N4 guessed.
+    # At -vv the comparison is printed whole.
+    cmd = ["poetry", "run", "pytest", "-vv", "--tb=short"]
     if continue_on_collection_errors:
         cmd.append("--continue-on-collection-errors")
     cmd.extend(test_files)

--- a/tests/unit/test_pytest_runs_at_vv.py
+++ b/tests/unit/test_pytest_runs_at_vv.py
@@ -1,0 +1,103 @@
+"""The runner's pytest carries -vv, so an assertion's compared values reach
+the implementer whole (#2924).
+
+boostgauge #4, `run-issue4-145211` (2026-09-06 14:52). The circular import
+fixed, the full suite running, one regression left -- the repo's
+`test_config.py` comparing `Thresholds()` to the config's defaults:
+
+    E   AssertionError: assert Thresholds(co...0, red=50000)) == Thresholds(co...0, red=20000))
+    E     Differing attributes:
+    E     ['conpty', 'memory_percent', 'process_count', 'handle_count']
+
+The four expected bands live in `config.py`, outside the plan; the one place
+they reach the implementer is that left-hand repr, and pytest truncates it
+at verbosity 1. The implementer guessed, the same test failed again, and
+the stagnation gate began counting.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes import verify_phases
+from assemblyzero.workflows.testing.nodes.verify_phases import run_pytest
+
+
+class TestTheRunnersArgv:
+    def test_the_targeted_run_is_vv(self, tmp_path: Path):
+        seen: list[list[str]] = []
+
+        def fake_run_command(cmd, **kwargs):
+            seen.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout="1 passed", stderr="")
+
+        with patch.object(verify_phases, "run_command", side_effect=fake_run_command):
+            run_pytest(["tests/unit/test_x.py"], repo_root=tmp_path)
+
+        assert seen[0][:5] == ["poetry", "run", "pytest", "-vv", "--tb=short"]
+        assert "-v" not in seen[0]
+
+    def test_the_full_suite_run_is_vv(self, tmp_path: Path):
+        seen: list[list[str]] = []
+
+        def fake_run_command(cmd, **kwargs):
+            seen.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout="119 passed", stderr="")
+
+        with patch.object(verify_phases, "run_command", side_effect=fake_run_command):
+            run_pytest([], repo_root=tmp_path)
+
+        assert seen[0][:5] == ["poetry", "run", "pytest", "-vv", "--tb=short"]
+
+
+class TestWhatVvBuys:
+    """pytest itself: the comparison run 44 needed, at -v and at -vv."""
+
+    CASE = '''\
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Band:
+    yellow: float
+    red: float
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    conpty: Band = Band(30, 60)
+    memory_percent: Band = Band(60, 80)
+    process_count: Band = Band(300, 500)
+    handle_count: Band = Band(30000, 20000)
+
+
+def test_thresholds_from_config_matches_the_collector_defaults():
+    expected = Thresholds(Band(30, 60), Band(60, 80), Band(300, 500), Band(30000, 50000))
+    assert expected == Thresholds()
+'''
+
+    def _run(self, tmp_path: Path, verbosity: str) -> str:
+        test_file = tmp_path / "test_run_44.py"
+        test_file.write_text(self.CASE, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test_file), verbosity, "--tb=short",
+             "-p", "no:cacheprovider"],
+            capture_output=True, text=True, cwd=str(tmp_path), timeout=120,
+        )
+        return result.stdout + result.stderr
+
+    def test_at_v_the_values_are_elided(self, tmp_path: Path):
+        output = self._run(tmp_path, "-v")
+
+        assert "Thresholds(co..." in output
+
+    def test_at_vv_run_44s_bands_are_all_there(self, tmp_path: Path):
+        output = self._run(tmp_path, "-vv")
+
+        assert "Thresholds(co..." not in output
+        assert "handle_count=Band(yellow=30000, red=50000)" in output
+        assert "handle_count=Band(yellow=30000, red=20000)" in output


### PR DESCRIPTION
## What happened

boostgauge #4, `run-issue4-145211` (2026-09-06 14:52). The circular import is fixed — the implementer wrote the lazy re-export #2922's block prescribed — and the full suite runs: 119 passed, one regression, the repo's `test_config.py` comparing `Thresholds()` to the config's defaults. What the implementer was handed:

```
tests/unit/test_config.py:331: in test_thresholds_from_config_matches_the_collector_defaults
    assert thresholds_from_config(DEFAULT_CONFIG) == Thresholds()
E   AssertionError: assert Thresholds(co...0, red=50000)) == Thresholds(co...0, red=20000))
E     Differing attributes:
E     ['conpty', 'memory_percent', 'process_count', 'handle_count']
```

The four expected bands live in `config.py`, a base file outside the plan. The one place they reach the implementer is the assertion's left-hand repr, and pytest truncates that at verbosity 1. The implementer guessed `red=20000` for the last band, the same test failed again, and the stagnation gate began counting.

## The change

`run_pytest` builds `["poetry", "run", "pytest", "-vv", "--tb=short"]`. At `-vv` pytest prints an assertion's comparison in full. Everything that reads the output — the PASSED/FAILED lines, the short summary, the coverage table — is unchanged in shape.

## Tests

`tests/unit/test_pytest_runs_at_vv.py`, four cases: the targeted run's argv carries `-vv` and no bare `-v`; the full-suite run's does too; and pytest itself, run on run 44's comparison in a scratch file, elides the bands at `-v` (`Thresholds(co...`) and prints every band on both sides at `-vv`.

The exit-code, coverage-target, collection-failure and failure-feedback suites pass unchanged. `ruff` clean.

**Before:** the argv carries `-v`, and the scratch case shows exactly run 44's elided line.

Closes #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
