### PR TITLE
fix(tools): the landed test workflow downloads the browser it needs (Closes #2936)

### DIFF
--- a/tools/land_polybolos_ci_workflow.py
+++ b/tools/land_polybolos_ci_workflow.py
@@ -147,6 +147,23 @@ jobs:
       - name: Install
         run: poetry install --no-interaction
 
+      # `poetry install` installs the Playwright PACKAGE. It does not download
+      # a browser, and two tests launch a real headless one on purpose: the
+      # defect they cover is what the browser does with scrollIntoView under
+      # `scroll-behavior: smooth`, which stopped the first live run on field one
+      # of twenty-five. A fake locator would test nothing but the test, so a
+      # browser-driving product's CI is exactly where they belong.
+      #
+      # ~130 MB cold, near-instant once the cache is warm.
+      - name: Cache the Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~\\AppData\\Local\\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install the Playwright browser
+        run: poetry run playwright install chromium
+
       - name: ruff
         run: poetry run ruff check .
 


### PR DESCRIPTION
Closes #2936

`poetry install` installs the Playwright *package*. It does not download a browser, and the workflow never asked it to — so the first CI run of the Polybolos suite failed two tests with:

```
BrowserType.launch: Executable doesn't exist at
C:\Users\runneradmin\AppData\Local\ms-playwright\chromium_headless_shell-1234\...
```

## Installed, not skipped

Those two tests launch a real headless browser **on purpose**, and their own docstring says why:

> The JS half runs in a real headless browser because the defect is in what the browser does with the call, and a FakeLocator would test nothing but the test.

They cover the smooth-scroll overlay defect that stopped that repo's first live run on field one of twenty-five. Skipping them would leave the suite green over the thing most worth checking, and a browser-driving product's CI is exactly where they belong.

Two steps before `pytest`: a cache on the browser directory keyed by the lock file, and `playwright install chromium`. About 130 MB cold, near-instant once warm.

## Checked before landing, again

The YAML was parsed, and the Windows cache path was asserted to carry **single** backslashes. The workflow is authored in a non-raw Python string literal, so a doubled backslash would have become a path no runner has — and a cache that silently misses is a slow build nobody investigates.

```
  Install                          run='poetry install --no-interaction'
  Cache the Playwright browser     path='~\AppData\Local\ms-playwright'
  Install the Playwright browser   run='poetry run playwright install chromium'
  ruff                             run='poetry run ruff check .'
  pytest                           run='poetry run pytest -n auto --junitxml=…'
  Every skip is declared           run='poetry run python tools/ci_skip_audit.py …'
```

The PUT is already idempotent — it reads the blob sha and updates in place — so re-running with `--apply` replaces the workflow file on the branch it is still open against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
